### PR TITLE
polish: fix encoding, import order, and style nits

### DIFF
--- a/easel/cli.py
+++ b/easel/cli.py
@@ -63,7 +63,7 @@ def cmd_chat(_args) -> int:
             identity = PROFILES_DIR / name / "identity.md"
             desc = ""
             if identity.is_file():
-                for line in identity.read_text().splitlines():
+                for line in identity.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if line and not line.startswith("#") and not line.startswith("<!--"):
                         desc = f"  — {line[:50]}"

--- a/easel/commands/doctor.py
+++ b/easel/commands/doctor.py
@@ -80,7 +80,7 @@ def _env_key_valid() -> bool:
     # 认证变量 → 是否已填入非占位值
     auth_vars: dict[str, str] = {}
     try:
-        for line in env_file.read_text().splitlines():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if line.startswith("#") or "=" not in line:
                 continue

--- a/easel/commands/skill.py
+++ b/easel/commands/skill.py
@@ -12,9 +12,11 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from easel.persona import persona_prefix, profile_exists
@@ -60,7 +62,7 @@ def _resolve_input(raw_input: str) -> str:
                       ".ogg", ".webm", ".mkv", ".avi", ".pdf", ".zip",
                       ".gz", ".tar", ".7z", ".rar"):
             return f"请处理这个文件：{p.resolve()}"
-        return p.read_text()
+        return p.read_text(encoding="utf-8")
     return raw_input
 
 
@@ -78,7 +80,6 @@ def _check_profile_exists(name: str) -> bool:
 
 def _proxy_env() -> dict[str, str]:
     """返回带外网代理的环境变量（保护内网直连）。"""
-    import os
     env = os.environ.copy()
     env.setdefault("EASEL_ROOT", str(PROJECT_ROOT))
     env.setdefault("http_proxy", os.environ.get("EASEL_PROXY", ""))
@@ -89,7 +90,6 @@ def _proxy_env() -> dict[str, str]:
 
 def _run_via_openclaw(message: str, timeout: int = 300) -> int:
     """统一通过 OpenClaw agent 执行。"""
-    import time
     session_key = f"skill-{int(time.time() * 1000)}"
 
     cmd = [
@@ -139,7 +139,7 @@ def cmd_skill(args) -> int:
 
     if skill_full is None:
         print(f"[easel] ERROR: SKILL '{skill_name}' 不存在")
-        print(f"  可用 SKILL:")
+        print("  可用 SKILL:")
         for name in _list_all_skills():
             print(f"    {name}")
         return 1

--- a/easel/persona.py
+++ b/easel/persona.py
@@ -44,12 +44,12 @@ def load_profile_text(name: str) -> str:
     for filename in _FILE_ORDER:
         filepath = profile_dir / filename
         if filepath.is_file():
-            text = filepath.read_text().strip()
+            text = filepath.read_text(encoding="utf-8").strip()
             if text:
                 parts.append(text)
     for filepath in sorted(profile_dir.glob("*.md")):
         if filepath.name not in _FILE_ORDER:
-            text = filepath.read_text().strip()
+            text = filepath.read_text(encoding="utf-8").strip()
             if text:
                 parts.append(text)
     return "\n\n---\n\n".join(parts)

--- a/web/app.py
+++ b/web/app.py
@@ -7,8 +7,8 @@ import hashlib
 import json
 import os
 import re
-import subprocess
 import shutil
+import subprocess
 import sys
 import tempfile
 import threading


### PR DESCRIPTION
- easel/persona.py: add encoding='utf-8' to both read_text() calls in load_profile_text() to avoid locale-dependent decoding on non-UTF-8 systems
- easel/cli.py: add encoding='utf-8' to identity.read_text() in cmd_chat()
- easel/commands/doctor.py: add encoding='utf-8' to env_file.read_text() in _env_key_valid()
- easel/commands/skill.py: move inline 'import os' and 'import time' from function bodies to module-level imports; add encoding='utf-8' to p.read_text() in _resolve_input(); remove redundant f-string on print("  可用 SKILL:")
- web/app.py: fix stdlib import ordering (shutil before subprocess, alphabetical order)