### PR TITLE
feat(web): render OpenClaw ask_user question cards in the chat UI

### DIFF
--- a/easel/cli.py
+++ b/easel/cli.py
@@ -102,7 +102,11 @@ def cmd_chat(_args) -> int:
 
     cmd = [
         "openclaw", "--profile", PROFILE,
-        "chat",
+        # 必须用 tui，不能用 chat：`chat`/`terminal` 是 `tui` 的别名，会强制本地模式
+        # （openclaw dist/tui-cli-*.js: invokedSubcommand === "chat" → isLocal = true）。
+        # 而 --local 要求独占 state 目录，与 Easel 自己启动的 gateway 冲突，
+        # 结果只会打印 "A Gateway is running for this state directory" 后直接退出。
+        "tui",
         "--session", session_key,
         # chat 里可能直接发起制作层/跨层编排，给足制作层预算，避免长任务被 turn 超时掐断（O2）。
         # 超时统一走 easel/timeouts.py（三入口单一真相源），毫秒 = TIMEOUT_CHAT * 1000。

--- a/easel/commands/ping.py
+++ b/easel/commands/ping.py
@@ -7,6 +7,8 @@ import subprocess
 import urllib.error
 import urllib.request
 
+from easel.openclaw_cmd import openclaw_base_cmd
+
 GREEN = "\033[0;32m"
 RED = "\033[0;31m"
 NC = "\033[0m"
@@ -60,11 +62,14 @@ def cmd_ping(_args) -> int:
     all_ok &= gateway_ok
 
     # Step 2: OpenClaw agent
+    oc_cmd = openclaw_base_cmd() + [
+        "--profile", "easel",
+        "agent", "--agent", "main",
+        "--timeout", "30", "--message", "say PONG",
+    ]
     all_ok &= _step(
         "Step 2: OpenClaw agent via Gateway (say PONG)",
-        ["openclaw", "--profile", "easel",
-         "agent", "--agent", "main",
-         "--timeout", "30", "--message", "say PONG"],
+        oc_cmd,
         timeout=60,
         env=_proxy_env(),
     )

--- a/easel/commands/skill.py
+++ b/easel/commands/skill.py
@@ -19,6 +19,7 @@ import sys
 import time
 from pathlib import Path
 
+from easel.openclaw_cmd import openclaw_base_cmd
 from easel.persona import persona_prefix, profile_exists
 from easel.timeouts import TIMEOUT_PRODUCE
 
@@ -92,8 +93,8 @@ def _run_via_openclaw(message: str, timeout: int = 300) -> int:
     """统一通过 OpenClaw agent 执行。"""
     session_key = f"skill-{int(time.time() * 1000)}"
 
-    cmd = [
-        "openclaw", "--profile", OPENCLAW_PROFILE,
+    cmd = openclaw_base_cmd() + [
+        "--profile", OPENCLAW_PROFILE,
         "agent", "--agent", "main",
         "--session-key", f"agent:main:{session_key}",
         "--timeout", str(timeout),

--- a/easel/gateway_questions.py
+++ b/easel/gateway_questions.py
@@ -47,13 +47,27 @@ CLIENT_ID = "cli"
 CLIENT_VERSION = "2026.9.2"
 
 
-def _client_platform() -> str:
-    """OpenClaw client platform tag derived from the actual host OS."""
+def _client_identity() -> dict:
+    """Client metadata tuple, mirroring OpenClaw's own platform mapping.
+
+    OpenClaw maps the Node platform to the *wire* identity it sends on connect
+    (src/shared/gateway-client-platform.ts):
+        darwin -> {"platform": "macos",   "deviceFamily": "Mac"}
+        win32  -> {"platform": "windows", "deviceFamily": "Windows"}
+        linux  -> {"platform": "linux",   "deviceFamily": "Linux"}
+
+    Both fields matter: the Gateway compares them against the paired device
+    record (resolvePinnedClientMetadata) and answers any mismatch with
+    requirePairing("metadata-upgrade") -> NOT_PAIRED, which kills this bridge.
+    Sending only "platform" (and using the raw "darwin" on macOS) reproduces
+    exactly that failure once the device was paired by any other OpenClaw
+    surface, which stores deviceFamily too.
+    """
     if sys.platform.startswith("win"):
-        return "windows"
+        return {"platform": "windows", "deviceFamily": "Windows"}
     if sys.platform == "darwin":
-        return "darwin"
-    return "linux"
+        return {"platform": "macos", "deviceFamily": "Mac"}
+    return {"platform": "linux", "deviceFamily": "Linux"}
 
 
 class GatewayQuestionError(RuntimeError):
@@ -162,7 +176,7 @@ class GatewayClient:
             "params": {
                 "minProtocol": GATEWAY_PROTOCOL_MIN, "maxProtocol": GATEWAY_PROTOCOL_MAX,
                 "client": {"id": CLIENT_ID, "version": CLIENT_VERSION,
-                           "platform": _client_platform(), "mode": "cli"},
+                           **_client_identity(), "mode": "cli"},
                 "role": "operator", "scopes": scopes,
                 "caps": [], "commands": [], "permissions": {},
                 "auth": {"token": dev["token"]},

--- a/easel/gateway_questions.py
+++ b/easel/gateway_questions.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
@@ -26,11 +28,32 @@ from pathlib import Path
 # --- path resolution -------------------------------------------------------
 
 HOME = Path.home()
-PROFILE_STATE_DIR = HOME / ".openclaw-easel" / "state"
+# Easel runs OpenClaw under an isolated `easel` profile at ~/.openclaw-easel/;
+# allow an override for non-default setups.
+PROFILE_DIR = Path(os.environ.get("EASEL_OPENCLAW_STATE_DIR") or (HOME / ".openclaw-easel"))
+PROFILE_STATE_DIR = PROFILE_DIR / "state"
 PROFILE_DB = PROFILE_STATE_DIR / "openclaw.sqlite"
 
-GATEWAY_HOST = "127.0.0.1"
-GATEWAY_PORT = 18789
+# Gateway loopback endpoint (default port 18789; overridable when reconfigured).
+GATEWAY_HOST = os.environ.get("EASEL_GATEWAY_HOST", "127.0.0.1")
+GATEWAY_PORT = int(os.environ.get("EASEL_GATEWAY_PORT", "18789"))
+
+# Gateway WS handshake constants. Kept here as a single source of truth rather
+# than buried in the connect payload — bump these to track OpenClaw's gateway
+# protocol / client contract.
+GATEWAY_PROTOCOL_MIN = 4
+GATEWAY_PROTOCOL_MAX = 4
+CLIENT_ID = "cli"
+CLIENT_VERSION = "2026.9.2"
+
+
+def _client_platform() -> str:
+    """OpenClaw client platform tag derived from the actual host OS."""
+    if sys.platform.startswith("win"):
+        return "windows"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "linux"
 
 
 class GatewayQuestionError(RuntimeError):
@@ -137,9 +160,9 @@ class GatewayClient:
         conn = {
             "type": "req", "id": "1", "method": "connect",
             "params": {
-                "minProtocol": 4, "maxProtocol": 4,
-                "client": {"id": "cli", "version": "2026.9.2",
-                           "platform": "windows", "mode": "cli"},
+                "minProtocol": GATEWAY_PROTOCOL_MIN, "maxProtocol": GATEWAY_PROTOCOL_MAX,
+                "client": {"id": CLIENT_ID, "version": CLIENT_VERSION,
+                           "platform": _client_platform(), "mode": "cli"},
                 "role": "operator", "scopes": scopes,
                 "caps": [], "commands": [], "permissions": {},
                 "auth": {"token": dev["token"]},

--- a/easel/gateway_questions.py
+++ b/easel/gateway_questions.py
@@ -1,0 +1,233 @@
+"""Gateway question-answer bridge for the Easel web UI.
+
+OpenClaw's `ask_user` tool registers a structured question on the Gateway
+(`question.request`, backed by `question.list` / `question.get` /
+`question.resolve` RPCs). The official Control UI renders these as a docked
+option card and answers them through the `operator.questions` RPC surface.
+
+The Easel web frontend is a custom React app that does not speak the Gateway
+WebSocket protocol, so ask_user cards never render and the agent blocks for
+the full timeout (default 900 s) before continuing with `no_answer`.
+
+This module is a minimal read/answer bridge: it connects to the loopback
+Gateway using the already-paired device identity (Ed25519 signature, v2
+payload), lists pending questions for a session, and resolves answers.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+# --- path resolution -------------------------------------------------------
+
+HOME = Path.home()
+PROFILE_STATE_DIR = HOME / ".openclaw-easel" / "state"
+PROFILE_DB = PROFILE_STATE_DIR / "openclaw.sqlite"
+
+GATEWAY_HOST = "127.0.0.1"
+GATEWAY_PORT = 18789
+
+
+class GatewayQuestionError(RuntimeError):
+    pass
+
+
+# --- device identity -------------------------------------------------------
+
+_DEVICE_CACHE: dict | None = None
+_DEVICE_LOCK = threading.Lock()
+
+
+def _load_device() -> dict:
+    """Load the paired CLI device identity + auth token from the state DB."""
+    global _DEVICE_CACHE
+    with _DEVICE_LOCK:
+        if _DEVICE_CACHE is not None:
+            return _DEVICE_CACHE
+        if not PROFILE_DB.is_file():
+            raise GatewayQuestionError(
+                f"gateway state db not found: {PROFILE_DB}")
+        con = sqlite3.connect(f"file:{PROFILE_DB}?mode=ro", uri=True)
+        try:
+            cur = con.cursor()
+            cur.execute(
+                "SELECT device_id, public_key_pem, private_key_pem "
+                "FROM device_identities WHERE identity_key='primary'")
+            row = cur.fetchone()
+            if not row:
+                raise GatewayQuestionError("no primary device identity in gateway db")
+            device_id, public_key_pem, private_key_pem = row
+            cur.execute(
+                "SELECT token FROM device_auth_tokens WHERE device_id=? AND role='operator'",
+                (device_id,))
+            tok = cur.fetchone()
+            if not tok:
+                raise GatewayQuestionError("no operator auth token for primary device")
+            # raw base64url public key (as stored in device_pairing_paired)
+            cur.execute(
+                "SELECT public_key FROM device_pairing_paired WHERE device_id=?",
+                (device_id,))
+            prow = cur.fetchone()
+            raw_pub = prow[0] if prow else None
+        finally:
+            con.close()
+        if not raw_pub:
+            raise GatewayQuestionError("paired public key not found")
+        _DEVICE_CACHE = {
+            "device_id": device_id,
+            "private_key_pem": private_key_pem,
+            "public_key": raw_pub,
+            "token": tok[0],
+        }
+        return _DEVICE_CACHE
+
+
+def _sign(payload: str) -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519  # noqa: F401
+
+    dev = _load_device()
+    key = serialization.load_pem_private_key(
+        dev["private_key_pem"].encode(), password=None)
+    sig = key.sign(payload.encode())
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+# --- websocket client ------------------------------------------------------
+
+class GatewayClient:
+    """Minimal Gateway WS RPC client (operator role, v2 device auth)."""
+
+    def __init__(self, timeout: float = 12.0):
+        import websocket  # local import: keep module import cheap
+
+        self._ws_lib = websocket
+        self.ws = None
+        self.timeout = timeout
+        self._seq = 0
+
+    def connect(self) -> None:
+        import websocket  # noqa: F401
+
+        dev = _load_device()
+        ws = self._ws_lib.create_connection(
+            f"ws://{GATEWAY_HOST}:{GATEWAY_PORT}", timeout=self.timeout)
+        try:
+            first = json.loads(ws.recv())
+            if first.get("event") != "connect.challenge":
+                raise GatewayQuestionError(
+                    f"expected connect.challenge, got {str(first)[:120]}")
+            nonce = first["payload"]["nonce"]
+            ts = first["payload"]["ts"]
+        except Exception:
+            ws.close()
+            raise
+
+        scopes = ["operator.admin", "operator.read", "operator.write"]
+        payload = "|".join([
+            "v2", dev["device_id"], "cli", "cli", "operator",
+            ",".join(scopes), str(ts), dev["token"], nonce,
+        ])
+        sig = _sign(payload)
+        conn = {
+            "type": "req", "id": "1", "method": "connect",
+            "params": {
+                "minProtocol": 4, "maxProtocol": 4,
+                "client": {"id": "cli", "version": "2026.9.2",
+                           "platform": "windows", "mode": "cli"},
+                "role": "operator", "scopes": scopes,
+                "caps": [], "commands": [], "permissions": {},
+                "auth": {"token": dev["token"]},
+                "device": {
+                    "id": dev["device_id"],
+                    "publicKey": dev["public_key"],
+                    "signature": sig,
+                    "signedAt": ts,
+                    "nonce": nonce,
+                },
+                "locale": "zh-CN",
+                "userAgent": "easel-web/0.1",
+            },
+        }
+        ws.send(json.dumps(conn))
+        ok = False
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            msg = json.loads(ws.recv())
+            if msg.get("id") == "1":
+                ok = msg.get("ok", False)
+                if not ok:
+                    raise GatewayQuestionError(
+                        f"gateway connect failed: {json.dumps(msg.get('error'))[:200]}")
+                break
+        if not ok:
+            ws.close()
+            raise GatewayQuestionError("gateway connect timed out")
+        self.ws = ws
+
+    def _rpc(self, method: str, params: dict, timeout: float | None = None):
+        if self.ws is None:
+            self.connect()
+        self._seq += 1
+        req_id = str(self._seq)
+        self.ws.send(json.dumps({
+            "type": "req", "id": req_id, "method": method, "params": params,
+        }))
+        deadline = time.time() + (timeout or self.timeout)
+        while time.time() < deadline:
+            msg = json.loads(self.ws.recv())
+            if msg.get("id") == req_id:
+                if not msg.get("ok", False):
+                    raise GatewayQuestionError(
+                        f"{method} failed: {json.dumps(msg.get('error'))[:200]}")
+                return msg.get("payload")
+        raise GatewayQuestionError(f"{method} timed out")
+
+    def list_questions(self, session_key: str | None = None,
+                       status: str | None = None) -> list[dict]:
+        payload = self._rpc("question.list", {}) or {}
+        items = payload.get("questions") or []
+        out = []
+        for q in items:
+            if session_key and q.get("sessionKey") != session_key:
+                continue
+            if status and q.get("status") != status:
+                continue
+            out.append(q)
+        return out
+
+    def get_question(self, question_id: str) -> dict | None:
+        payload = self._rpc("question.get", {"id": question_id})
+        return (payload or {}).get("question")
+
+    def resolve(self, question_id: str, answers: dict,
+                resolved_by: str | None = None) -> dict:
+        params = {
+            "id": question_id,
+            "answers": {"answers": answers},
+        }
+        if resolved_by:
+            params["resolvedBy"] = resolved_by
+        return self._rpc("question.resolve", params) or {}
+
+    def close(self) -> None:
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+            self.ws = None
+
+
+def pending_questions_for_session(session_key: str) -> list[dict]:
+    """Convenience: list pending questions belonging to a session."""
+    client = GatewayClient()
+    try:
+        return client.list_questions(session_key=session_key, status="pending")
+    finally:
+        client.close()

--- a/easel/openclaw_cmd.py
+++ b/easel/openclaw_cmd.py
@@ -1,11 +1,16 @@
-"""Resolve the openclaw executable as [node, openclaw.mjs].
+"""Resolve how to invoke the openclaw CLI as an argv prefix.
 
 Windows pitfall this solves: `openclaw` on PATH is a `.cmd` shim. Python's
 CreateProcess cannot run it directly, and wrapping in cmd.exe /c breaks
 messages containing newlines (cmd treats the rest of the line as a separate
-command -> "your message got cut off" / silently truncated input).
+command -> "your message got cut off" / silently truncated input). Running
+`node openclaw.mjs` directly avoids both problems.
 
-Running node + openclaw.mjs directly avoids both problems on all platforms.
+On Linux/macOS `openclaw` on PATH is a real executable (a symlink to
+`openclaw.mjs` with a `#!/usr/bin/env node` shebang), so running it directly
+is fine. The resolution below therefore prefers `node + openclaw.mjs` when it
+can locate the script (robust everywhere, mandatory on Windows), and falls
+back to the PATH `openclaw` executable rather than hard-failing.
 """
 
 from __future__ import annotations
@@ -17,22 +22,42 @@ from pathlib import Path
 
 @lru_cache(maxsize=1)
 def openclaw_base_cmd() -> list[str]:
-    """Return [node, /path/to/openclaw.mjs] (raise FileNotFoundError if missing)."""
-    node = shutil.which("node")
-    if not node:
-        raise FileNotFoundError("node not found on PATH")
+    """Return the argv prefix for invoking openclaw.
 
-    node_dir = Path(node).resolve().parent
-    candidates = [
-        # npm global prefix == node dir (zip/nvm-style installs)
-        node_dir / "node_modules" / "openclaw" / "openclaw.mjs",
-        # npm global prefix == %APPDATA%/npm (standard Windows installs)
-        Path.home() / "AppData" / "Roaming" / "npm" / "node_modules" / "openclaw" / "openclaw.mjs",
-    ]
-    for cand in candidates:
-        if cand.is_file():
-            return [node, str(cand)]
+    Prefers ``[node, /path/to/openclaw.mjs]``; falls back to ``[openclaw]`` on
+    PATH. Raises FileNotFoundError only when openclaw cannot be located at all.
+    """
+    node = shutil.which("node")
+    oc = shutil.which("openclaw")
+
+    # 1) PATH `openclaw` that resolves to the .mjs (Unix symlink, or a direct
+    #    .mjs on PATH): run it through node explicitly.
+    if oc and node:
+        resolved = Path(oc).resolve()
+        if resolved.suffix == ".mjs" and resolved.is_file():
+            return [node, str(resolved)]
+
+    # 2) Hunt for openclaw.mjs under the known npm global layouts.
+    if node:
+        node_dir = Path(node).resolve().parent
+        candidates = [
+            # Unix standard: <prefix>/bin/node -> <prefix>/lib/node_modules/...
+            node_dir.parent / "lib" / "node_modules" / "openclaw" / "openclaw.mjs",
+            # npm global prefix == node dir (zip / some nvm-style installs)
+            node_dir / "node_modules" / "openclaw" / "openclaw.mjs",
+            # Windows standard: npm global prefix == %APPDATA%/npm
+            Path.home() / "AppData" / "Roaming" / "npm" / "node_modules" / "openclaw" / "openclaw.mjs",
+        ]
+        for cand in candidates:
+            if cand.is_file():
+                return [node, str(cand)]
+
+    # 3) Fallback: run the PATH `openclaw` directly. On Unix this is a real
+    #    executable and works. On Windows this is the `.cmd` shim (only reached
+    #    when the .mjs truly can't be found) — still better than hard-failing.
+    if oc:
+        return [oc]
 
     raise FileNotFoundError(
-        "openclaw.mjs not found under npm global dirs (node_dir / %APPDATA%/npm)"
+        "openclaw CLI not found: no 'node'+openclaw.mjs and no 'openclaw' on PATH"
     )

--- a/easel/openclaw_cmd.py
+++ b/easel/openclaw_cmd.py
@@ -1,0 +1,38 @@
+"""Resolve the openclaw executable as [node, openclaw.mjs].
+
+Windows pitfall this solves: `openclaw` on PATH is a `.cmd` shim. Python's
+CreateProcess cannot run it directly, and wrapping in cmd.exe /c breaks
+messages containing newlines (cmd treats the rest of the line as a separate
+command -> "your message got cut off" / silently truncated input).
+
+Running node + openclaw.mjs directly avoids both problems on all platforms.
+"""
+
+from __future__ import annotations
+
+import shutil
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache(maxsize=1)
+def openclaw_base_cmd() -> list[str]:
+    """Return [node, /path/to/openclaw.mjs] (raise FileNotFoundError if missing)."""
+    node = shutil.which("node")
+    if not node:
+        raise FileNotFoundError("node not found on PATH")
+
+    node_dir = Path(node).resolve().parent
+    candidates = [
+        # npm global prefix == node dir (zip/nvm-style installs)
+        node_dir / "node_modules" / "openclaw" / "openclaw.mjs",
+        # npm global prefix == %APPDATA%/npm (standard Windows installs)
+        Path.home() / "AppData" / "Roaming" / "npm" / "node_modules" / "openclaw" / "openclaw.mjs",
+    ]
+    for cand in candidates:
+        if cand.is_file():
+            return [node, str(cand)]
+
+    raise FileNotFoundError(
+        "openclaw.mjs not found under npm global dirs (node_dir / %APPDATA%/npm)"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "faster-whisper>=1,<2", "edge-tts>=6,<8", "playwright>=1.45,<2",
     "rembg>=2.0,<3", "biliup>=1,<2", "jieba>=0.42,<1", "snownlp>=0.12,<1",
     "markdown>=3.5,<4",
+    # ask_user 问答题桥接（easel/gateway_questions.py）：连本地 gateway WS RPC + Ed25519 设备签名
+    "websocket-client>=1.7,<2",
+    "cryptography>=42,<45",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ dependencies = [
     "rembg>=2.0,<3", "biliup>=1,<2", "jieba>=0.42,<1", "snownlp>=0.12,<1",
     "markdown>=3.5,<4",
     # ask_user 问答题桥接（easel/gateway_questions.py）：连本地 gateway WS RPC + Ed25519 设备签名
+    # 只用到 load_pem_private_key + Ed25519.sign（长期稳定 API），上界放宽避免与新版冲突
     "websocket-client>=1.7,<2",
-    "cryptography>=42,<45",
+    "cryptography>=42",
 ]
 
 [project.scripts]

--- a/setup.ps1
+++ b/setup.ps1
@@ -132,7 +132,7 @@ if (Is-UsableKey $envValues['OPENAI_MAAS_API_KEY'] -and $envValues.ContainsKey('
     OpenClaw-Config 'agents.defaults.model.primary' "rednote-openai/$model"
 } elseif (Is-UsableKey $envValues['OPENAI_API_KEY']) {
     $model = if ($envValues.ContainsKey('OPENAI_MODEL')) { $envValues['OPENAI_MODEL'] } else { 'gpt-4o' }
-    $models = @(@{ id = $model; name = 'OpenAI model'; reasoning = $true; input = @('text', 'image') }) | ConvertTo-Json -Compress -Depth 5
+    $models = @(@{ id = $model; name = 'OpenAI model'; reasoning = $true; input = @('text', 'image') }) | ConvertTo-Json -Compress -Depth 5 -AsArray
     OpenClaw-Config 'models.providers.openai.api' 'openai-completions'; OpenClaw-Config 'models.providers.openai.apiKey' $envValues['OPENAI_API_KEY']; OpenClaw-Config 'models.providers.openai.baseUrl' $(if ($envValues.ContainsKey('OPENAI_BASE_URL')) { $envValues['OPENAI_BASE_URL'] } else { 'https://api.openai.com/v1' }); OpenClaw-Config 'models.providers.openai.models' $models -Json; OpenClaw-Config 'agents.defaults.model.primary' "openai/$model"
 } elseif (Is-UsableKey $envValues['EASEL_LLM_API_KEY'] -and $envValues.ContainsKey('EASEL_LLM_BASE_URL')) {
     OpenClaw-Config 'models.providers.anthropic.apiKey' $envValues['EASEL_LLM_API_KEY']; OpenClaw-Config 'models.providers.anthropic.baseUrl' $envValues['EASEL_LLM_BASE_URL']; OpenClaw-Config 'models.providers.anthropic.headers.api-key' $envValues['EASEL_LLM_API_KEY']; OpenClaw-Config 'agents.defaults.model.primary' $(if ($envValues.ContainsKey('CLAUDE_MODEL')) { $envValues['CLAUDE_MODEL'] } else { 'anthropic/claude-sonnet-4-6' })

--- a/web/app.py
+++ b/web/app.py
@@ -1178,8 +1178,14 @@ async def api_chat_stream(req: ChatRequest):
                 try:
                     client = GatewayClient()
                     client.connect()
-                except Exception:
-                    return  # gateway 不可达：不阻塞对话主流程（本轮退化为无选项，agent 会 no_answer 自行续）
+                except Exception as e:
+                    # gateway 不可达：不阻塞对话主流程（本轮退化为无选项，agent 会 no_answer 自行续）。
+                    # 但要留下痕迹：设备未配对或客户端元数据不匹配时这里会持续失败，
+                    # 前端表现仅仅是「卡片不出现」，静默 return 会让人完全无从排查。
+                    print(f"[question-bridge] connect gateway failed, "
+                          f"no ask_user cards this turn: {e}",
+                          file=sys.stderr, flush=True)
+                    return
                 try:
                     while proc.poll() is None:
                         try:

--- a/web/app.py
+++ b/web/app.py
@@ -34,8 +34,14 @@ if str(PROJECT_ROOT) not in sys.path:
 if str(PROJECT_ROOT / "scripts") not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+from easel.openclaw_cmd import openclaw_base_cmd
 from easel.persona import load_profile_text, persona_prefix, chat_turn_message, profile_exists, _FILE_ORDER
 from easel.timeouts import TIMEOUT_CHAT, TIMEOUT_DIRECT, TIMEOUT_PRODUCE
+try:
+    from easel.gateway_questions import GatewayClient, GatewayQuestionError
+except Exception:  # 兼容缺失依赖：问答题桥接降级为关闭
+    GatewayClient = None  # type: ignore
+    GatewayQuestionError = None  # type: ignore
 
 PROFILES_DIR = PROJECT_ROOT / "profiles"
 SKILLS_DIR = PROJECT_ROOT / "skills"
@@ -436,7 +442,7 @@ def run_agent_sync(msg: str, timeout: int = TIMEOUT_DIRECT, session_id: str | No
     sk = session_id or f'web-{int(time.time() * 1000)}'
     _heal_openclaw_session(sk)   # 清洗历史里无签名 thinking 块，防回放失效
     # 钉死 --session-id 让 OpenClaw 每轮续同一 transcript（防跨天空闲后新起空会话丢历史，见 _openclaw_session_id）
-    cmd = ['openclaw', '--profile', OPENCLAW_PROFILE, 'agent', '--agent', 'main',
+    cmd = openclaw_base_cmd() + ['--profile', OPENCLAW_PROFILE, 'agent', '--agent', 'main',
            '--session-key', f'agent:main:{sk}', '--session-id', _openclaw_session_id(sk),
            '--thinking', THINKING_LEVEL,
            '--timeout', str(timeout), '--message', msg]
@@ -1077,8 +1083,8 @@ async def api_chat_stream(req: ChatRequest):
         os.close(fd)
         raw_path = Path(raw_path)
 
-        cmd = [
-            "openclaw", "--profile", OPENCLAW_PROFILE, "agent", "--agent", "main",
+        cmd = openclaw_base_cmd() + [
+            "--profile", OPENCLAW_PROFILE, "agent", "--agent", "main",
             "--session-key", f"agent:main:{sk}", "--session-id", _openclaw_session_id(sk),
             "--thinking", THINKING_LEVEL,
             "--timeout", str(TIMEOUT_CHAT), "--message", message,
@@ -1131,6 +1137,7 @@ async def api_chat_stream(req: ChatRequest):
             client_q.put_nowait(CLIENT_DONE)
             return
         _RUNNING_CHAT[sk] = proc         # 注册运行中进程，供 /api/chat/stop 显式终止
+
         q = asyncio.Queue()
         SENTINEL = object()
         stdout_lines = []
@@ -1159,6 +1166,45 @@ async def api_chat_stream(req: ChatRequest):
 
         def _emit(kind: str, text: str):
             loop.call_soon_threadsafe(q.put_nowait, {"t": kind, "text": text})
+
+        # ---- ask_user 问答题桥接：轮询 gateway 的 pending question，推给前端渲染 ----
+        # 背景：OpenClaw 的 ask_user 注册到 gateway 进程内，Easel 前端不消费 question RPC → 选项不可见。
+        # 这里在 agent 运行期间每 2s 轮询一次，把新出现的 pending question 以 SSE `question` 事件推送，
+        # 前端渲染选项卡片；用户点击后经 /api/chat/question/answer 调 question.resolve 完成回答。
+        if GatewayClient is not None:
+            def _question_poll():
+                client = None
+                pushed: set[str] = set()
+                try:
+                    client = GatewayClient()
+                    client.connect()
+                except Exception:
+                    return  # gateway 不可达：不阻塞对话主流程（本轮退化为无选项，agent 会 no_answer 自行续）
+                try:
+                    while proc.poll() is None:
+                        try:
+                            items = client.list_questions(
+                                session_key=f"agent:main:{sk}", status="pending")
+                        except Exception:
+                            time.sleep(2)
+                            continue
+                        for it in items:
+                            qid = it.get("id")
+                            if qid and qid not in pushed:
+                                pushed.add(qid)
+                                _emit("question", json.dumps({
+                                    "id": qid,
+                                    "questions": it.get("questions", []),
+                                    "expiresAtMs": it.get("expiresAtMs"),
+                                }, ensure_ascii=False))
+                        time.sleep(2)
+                finally:
+                    try:
+                        if client is not None:
+                            client.close()
+                    except Exception:
+                        pass
+            loop.run_in_executor(None, _question_poll)
 
         def _handle(line: str):
             o = _raw_event_for_session(line, expected_raw_session_id)
@@ -1248,6 +1294,8 @@ async def api_chat_stream(req: ChatRequest):
                     to_client("thinking", item["text"])
                 elif item["t"] == "activity":
                     to_client("activity", item["text"])
+                elif item["t"] == "question":
+                    to_client("question", item["text"])
             rc = proc.poll()
             # 等 stdout 读完（stopReason 行在进程收尾时才打印，避免 _tail 先发 SENTINEL 时漏读）
             try:
@@ -1393,12 +1441,63 @@ async def api_chat_stream(req: ChatRequest):
                 yield {"id": str(item["id"]), "event": "thinking", "data": json.dumps(item["text"], ensure_ascii=False)}
             elif t == "activity":
                 yield {"id": str(item["id"]), "event": "activity", "data": json.dumps(item["text"], ensure_ascii=False)}
+            elif t == "question":
+                yield {"id": str(item["id"]), "event": "question", "data": item["text"]}
             elif t == "error":
                 yield {"id": str(item["id"]), "event": "error", "data": json.dumps(item["text"], ensure_ascii=False)}
             elif t == "done":
                 yield {"id": str(item["id"]), "event": "done", "data": json.dumps({"sessionKey": item.get("sessionKey")}, ensure_ascii=False)}
 
     return EventSourceResponse(forward(), headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no", "Content-Encoding": "identity"})
+
+
+class QuestionAnswerRequest(BaseModel):
+    sessionId: str | None = None
+    questionId: str
+    answers: dict  # {questionId: [optionValues]}
+    resolvedBy: str | None = None
+
+
+@app.post("/api/chat/question/answer")
+async def api_question_answer(req: QuestionAnswerRequest):
+    """前端点击 ask_user 选项后调用：转发 gateway question.resolve，让等待的 agent 拿到答案。"""
+    if GatewayClient is None:
+        return {"ok": False, "error": "gateway question bridge unavailable"}
+    client = GatewayClient()
+    try:
+        client.connect()
+        result = client.resolve(req.questionId, req.answers or {}, req.resolvedBy)
+        return {"ok": True, "result": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+    finally:
+        client.close()
+
+
+class QuestionStatusRequest(BaseModel):
+    questionIds: list[str]
+
+
+@app.post("/api/chat/question/status")
+async def api_question_status(req: QuestionStatusRequest):
+    """批量查 question 状态（重放旧事件时过滤已解决的题）。"""
+    if GatewayClient is None:
+        return {"ok": False, "questions": {}}
+    client = GatewayClient()
+    try:
+        client.connect()
+        out = {}
+        for qid in req.questionIds:
+            try:
+                q = client.get_question(qid)
+                out[qid] = {"status": q.get("status") if q else "not_found"}
+            except Exception:
+                out[qid] = {"status": "unknown"}
+        return {"ok": True, "questions": out}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "questions": {}}
+    finally:
+        client.close()
 
 
 class StopRequest(BaseModel):

--- a/web/app.py
+++ b/web/app.py
@@ -1490,9 +1490,13 @@ async def api_question_status(req: QuestionStatusRequest):
         for qid in req.questionIds:
             try:
                 q = client.get_question(qid)
+                # QUESTION_NOT_FOUND 抛异常捕获后报 not_found；正常返回则按 status
                 out[qid] = {"status": q.get("status") if q else "not_found"}
+            except GatewayQuestionError as e:
+                # gateway 明确错：问题已清理/不存在 = 已答或已过期，一律 not_found
+                out[qid] = {"status": "not_found"}
             except Exception:
-                out[qid] = {"status": "unknown"}
+                out[qid] = {"status": "unknown"}   # 网络/连接异常：保持 unknown（前端保留显示，宁不缺题）
         return {"ok": True, "questions": out}
     except Exception as e:
         return {"ok": False, "error": str(e), "questions": {}}

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -167,6 +167,43 @@ export default function App() {
   const streamCtl = useRef<Record<string, AbortController>>({});
   const streamAcc = useRef<Record<string, { content: string; thinking: string; steps: string[]; questions: ChatQuestion[] }>>({});
   const answeredRef = useRef<Set<string>>(new Set());   // 已提交答案的 question id：重放/恢复不再重现
+  // ---- 打字机：分批到达的 token 按节奏吐给界面 ----
+  const typingBuf = useRef<Record<string, string>>({});
+  const typingTimer = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+  const TYPING_INTERVAL = 12;          // 每 tick 间隔 ms（短回复约 83 字/秒：快且有逐字感）
+
+  const pumpTyping = (sessionId: string) => {
+    const buf = typingBuf.current[sessionId] || '';
+    if (!buf) { clearTyping(sessionId); return; }
+    // 动态步长：<80 字逐字吐（83字/秒），每满 80 字每 tick 多吐 1 字，长文更快
+    const step = Math.max(1, Math.floor(buf.length / 80));
+    const take = buf.slice(0, step);
+    typingBuf.current[sessionId] = buf.slice(step);
+    const a = streamAcc.current[sessionId]; if (!a) { clearTyping(sessionId); return; }
+    a.content += take;
+    setStreams((p) => (p[sessionId] ? { ...p, [sessionId]: { ...p[sessionId], content: a.content } } : p));
+  };
+  const startTypingPump = (sessionId: string) => {
+    if (typingTimer.current[sessionId]) return;
+    typingTimer.current[sessionId] = setInterval(() => pumpTyping(sessionId), TYPING_INTERVAL);
+  };
+  const ensureTypingPump = (sessionId: string) => {
+    if (!typingTimer.current[sessionId]) startTypingPump(sessionId);
+  };
+  const clearTyping = (sessionId: string) => {
+    const t = typingTimer.current[sessionId];
+    if (t) { clearInterval(t); delete typingTimer.current[sessionId]; }
+  };
+  /** 收尾冲刷：把剩余队列立刻吐完（避免结束瞬间内容被截断）。 */
+  const flushTyping = (sessionId: string) => {
+    clearTyping(sessionId);
+    const buf = typingBuf.current[sessionId] || '';
+    if (!buf) return;
+    typingBuf.current[sessionId] = '';
+    const a = streamAcc.current[sessionId]; if (!a) return;
+    a.content += buf;
+    setStreams((p) => (p[sessionId] ? { ...p, [sessionId]: { ...p[sessionId], content: a.content } } : p));
+  };
 
   const appendAssistant = useCallback((sessionId: string, msg: ChatMessage, sessionKey?: string) => {
     setSessions((prev) => {
@@ -180,6 +217,8 @@ export default function App() {
   }, []);
 
   const clearStream = useCallback((sessionId: string) => {
+    // 打字机收尾：剩余队列立刻吐出，避免结束瞬间内容被截断
+    flushTyping(sessionId);
     delete streamCtl.current[sessionId];
     delete streamAcc.current[sessionId];
     setStreams((prev) => {
@@ -204,30 +243,51 @@ export default function App() {
     });
     streamAcc.current[sessionId] = { content: '', thinking: '', steps: [], questions: [] };
     setStreams((prev) => ({ ...prev, [sessionId]: { content: '', thinking: '', activity: '', questions: [] } }));
+    // 打字机队列：流式事件按批到达（OpenClaw 攒批），前端按字符节奏显示，体验逐字浮现。
+    typingBuf.current[sessionId] = '';
+    startTypingPump(sessionId);
     streamCtl.current[sessionId] = streamChat(
       text, persona, sessionId,
       (chunk) => {
-        const a = streamAcc.current[sessionId]; if (!a) return; a.content += chunk;
-        setStreams((p) => (p[sessionId] ? { ...p, [sessionId]: { ...p[sessionId], content: a.content } } : p));
+        const a = streamAcc.current[sessionId]; if (!a) return;
+        // 不直接追加 content——进打字机队列，pump 按节奏吐出（切会话不中断，队列归属 sessionId）
+        typingBuf.current[sessionId] = (typingBuf.current[sessionId] || '') + chunk;
+        ensureTypingPump(sessionId);
       },
       (sessionKey) => {
-        const a = streamAcc.current[sessionId];
-        appendAssistant(sessionId, {
-          role: 'assistant', content: a?.content || '',
-          thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
-        }, sessionKey);
-        clearStream(sessionId);
-        try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        // done 不能立即 flush——token 和 done 几乎同时到达（OpenClaw 攒批），
+        // 立即 flush 会把整包瞬间冲出，打字机白做。等队列吐完再落盘。
+        const waitAndFinalize = () => {
+          if (typingBuf.current[sessionId]) {
+            setTimeout(waitAndFinalize, 60);
+            return;
+          }
+          const a = streamAcc.current[sessionId];
+          appendAssistant(sessionId, {
+            role: 'assistant', content: a?.content || '',
+            thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
+          }, sessionKey);
+          clearStream(sessionId);
+          try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        };
+        waitAndFinalize();
       },
       (err) => {
-        const a = streamAcc.current[sessionId];
-        appendAssistant(sessionId, {
-          role: 'assistant',
-          content: (a?.content ? a.content + '\n\n' : '') + `Error: ${err.message}`,
-          thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
-        });
-        clearStream(sessionId);
-        try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        const waitAndFinalize = () => {
+          if (typingBuf.current[sessionId]) {
+            setTimeout(waitAndFinalize, 60);
+            return;
+          }
+          const a = streamAcc.current[sessionId];
+          appendAssistant(sessionId, {
+            role: 'assistant',
+            content: (a?.content ? a.content + '\n\n' : '') + `Error: ${err.message}`,
+            thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
+          });
+          clearStream(sessionId);
+          try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        };
+        waitAndFinalize();
       },
       (thinkChunk) => {
         const a = streamAcc.current[sessionId]; if (!a) return;
@@ -279,6 +339,8 @@ export default function App() {
     try { turnId = sessionStorage.getItem(`easel_pending_turn:${sessionId}`) || turnId; } catch { /* use persisted id */ }
     streamAcc.current[sessionId] = { content: '', thinking: '', steps: [], questions: [] };
     setStreams((p) => ({ ...p, [sessionId]: { content: '', thinking: '', activity: '⏳ 正在接回上一轮结果…', questions: [] } }));
+    typingBuf.current[sessionId] = '';
+    startTypingPump(sessionId);
     if (!turnId) {
       void fetchLastTurn(sessionId).then((r) => {
         if (r.status === 'done') appendAssistant(sessionId, { role: 'assistant', content: r.text || '（无输出）' });
@@ -289,22 +351,37 @@ export default function App() {
     streamCtl.current[sessionId] = streamChat(
       '', undefined, sessionId,
       (chunk) => {
-        const a = streamAcc.current[sessionId]; if (!a) return; a.content += chunk;
-        setStreams((p) => (p[sessionId] ? { ...p, [sessionId]: { ...p[sessionId], content: a.content } } : p));
+        const a = streamAcc.current[sessionId]; if (!a) return;
+        typingBuf.current[sessionId] = (typingBuf.current[sessionId] || '') + chunk;
+        ensureTypingPump(sessionId);
       },
       (sessionKey) => {
-        const a = streamAcc.current[sessionId];
-        appendAssistant(sessionId, {
-          role: 'assistant', content: a?.content || '（无输出）',
-          thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
-        }, sessionKey);
-        clearStream(sessionId);
-        try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        const waitAndFinalize = () => {
+          if (typingBuf.current[sessionId]) {
+            setTimeout(waitAndFinalize, 60);
+            return;
+          }
+          const a = streamAcc.current[sessionId];
+          appendAssistant(sessionId, {
+            role: 'assistant', content: a?.content || '（无输出）',
+            thinking: a?.thinking || undefined, activity: a?.steps.join('\n') || undefined,
+          }, sessionKey);
+          clearStream(sessionId);
+          try { sessionStorage.removeItem(`easel_pending_turn:${sessionId}`); } catch { /* ignore */ }
+        };
+        waitAndFinalize();
       },
       (err) => {
-        const a = streamAcc.current[sessionId];
-        appendAssistant(sessionId, { role: 'assistant', content: (a?.content || '') + `\n\nError: ${err.message}` });
-        clearStream(sessionId);
+        const waitAndFinalize = () => {
+          if (typingBuf.current[sessionId]) {
+            setTimeout(waitAndFinalize, 60);
+            return;
+          }
+          const a = streamAcc.current[sessionId];
+          appendAssistant(sessionId, { role: 'assistant', content: (a?.content || '') + `\n\nError: ${err.message}` });
+          clearStream(sessionId);
+        };
+        waitAndFinalize();
       },
       (chunk) => { const a = streamAcc.current[sessionId]; if (a) a.thinking = (a.thinking + chunk).slice(-4000); },
       (status) => {
@@ -428,6 +505,7 @@ export default function App() {
     streamCtl.current[sessionId]?.abort();
     // 告诉后端**真正终止**这一轮 agent 并释放会话锁——否则后端进程还在跑、占着锁，下一句会被拦
     void stopChat(sessionId).catch(() => { /* 后端可能已结束，忽略 */ });
+    flushTyping(sessionId);   // 停止时立刻把队列余字吐完，保证已到内容不丢
     const a = streamAcc.current[sessionId];
     if (a && (a.content || a.thinking || a.steps.length)) {
       appendAssistant(sessionId, {

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -166,6 +166,7 @@ export default function App() {
   const [streams, setStreams] = useState<Record<string, StreamState>>({});
   const streamCtl = useRef<Record<string, AbortController>>({});
   const streamAcc = useRef<Record<string, { content: string; thinking: string; steps: string[]; questions: ChatQuestion[] }>>({});
+  const answeredRef = useRef<Set<string>>(new Set());   // 已提交答案的 question id：重放/恢复不再重现
 
   const appendAssistant = useCallback((sessionId: string, msg: ChatMessage, sessionKey?: string) => {
     setSessions((prev) => {
@@ -253,9 +254,11 @@ export default function App() {
         // 重放可能带已解决/已过期的旧问题，先查状态只留 pending（失败则保留）
         const a = streamAcc.current[sessionId]; if (!a) return;
         if (a.questions.some((x) => x.id === q.id)) return;
+        if (answeredRef.current.has(q.id)) return;   // 本会话已答过：不再重现
         void questionStatus([q.id]).then((st) => {
           const s = st[q.id]?.status;
-          if (s && s !== 'pending') return;
+          // 只显示仍 pending 的：answered/expired/cancelled/not_found/unknown 一律过滤
+          if (s && s !== 'pending' || answeredRef.current.has(q.id)) return;
           const a2 = streamAcc.current[sessionId]; if (!a2) return;
           if (a2.questions.some((x) => x.id === q.id)) return;
           a2.questions.push(q);
@@ -338,11 +341,14 @@ export default function App() {
       (q) => {
         const a = streamAcc.current[sessionId]; if (!a) return;
         if (a.questions.some((x) => x.id === q.id)) return;
+        if (answeredRef.current.has(q.id)) return;   // 本会话已答过：不再重现
         // 重放可能带已解决/已过期的旧问题（gateway 15s 后即清理）——先查状态只留 pending；
         // 查询失败时保留原样（宁显示不丢题）。
         void questionStatus([q.id]).then((st) => {
           const s = st[q.id]?.status;
-          if (s && s !== 'pending') return;   // answered/expired/cancelled/not_found：过滤
+          // 只显示仍 pending 的：answered/expired/cancelled/not_found/unknown 一律过滤
+          //（unknown 通常=问题已从 gateway 清理，即已答或已过期，重放旧事件时不该重现）
+          if (s && s !== 'pending' || answeredRef.current.has(q.id)) return;
           const a2 = streamAcc.current[sessionId]; if (!a2) return;
           if (a2.questions.some((x) => x.id === q.id)) return;
           a2.questions.push(q);
@@ -589,6 +595,23 @@ export default function App() {
             onResend={(userIndex, displayText, attachments, legacyAgentText) => handleResend(
               activeSession.id, userIndex, displayText, attachments, legacyAgentText,
             )}
+            onQuestionAnswered={(qid) => {
+              answeredRef.current.add(qid);
+              // 已答题从流式状态中移除——切走/切回会话都不再重现（组件内部 state 会在重挂时清零，只藏不移除没用）
+              const a = streamAcc.current[activeSession.id];
+              if (a) {
+                const before = a.questions.length;
+                const kept = a.questions.filter((q) => q.id !== qid);
+                if (kept.length !== before) {
+                  a.questions = kept;
+                  setStreams((p) => {
+                    const cur = p[activeSession.id];
+                    if (!cur) return p;
+                    return { ...p, [activeSession.id]: { ...cur, questions: [...kept] } };
+                  });
+                }
+              }
+            }}
           />
         ) : null;
       case 'trends':

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -15,7 +15,8 @@ import BreakdownPage from './components/BreakdownPage';
 import SubNav from './components/SubNav';
 import OnboardingWizard from './components/OnboardingWizard';
 import { fetchStatus, fetchPersonas, streamChat, fetchLastTurn, stopChat } from './lib/api';
-import type { PersonaItem, UploadedFile } from './lib/api';
+import type { PersonaItem, UploadedFile, ChatQuestion } from './lib/api';
+import { questionStatus } from './lib/api';
 import { deleteSession as deleteRemoteSession } from './lib/api';
 import {
   loadSessions,
@@ -164,7 +165,7 @@ export default function App() {
   // ---- 流式对话：状态与生命周期都放在 App（永不卸载），切页/切 ChatPage 都不中断/丢失 ----
   const [streams, setStreams] = useState<Record<string, StreamState>>({});
   const streamCtl = useRef<Record<string, AbortController>>({});
-  const streamAcc = useRef<Record<string, { content: string; thinking: string; steps: string[] }>>({});
+  const streamAcc = useRef<Record<string, { content: string; thinking: string; steps: string[]; questions: ChatQuestion[] }>>({});
 
   const appendAssistant = useCallback((sessionId: string, msg: ChatMessage, sessionKey?: string) => {
     setSessions((prev) => {
@@ -200,8 +201,8 @@ export default function App() {
       const next = prev.map((s) => (s.id === sessionId ? { ...s, pendingTurnId: turnId } : s));
       saveSessions(next); return next;
     });
-    streamAcc.current[sessionId] = { content: '', thinking: '', steps: [] };
-    setStreams((prev) => ({ ...prev, [sessionId]: { content: '', thinking: '', activity: '' } }));
+    streamAcc.current[sessionId] = { content: '', thinking: '', steps: [], questions: [] };
+    setStreams((prev) => ({ ...prev, [sessionId]: { content: '', thinking: '', activity: '', questions: [] } }));
     streamCtl.current[sessionId] = streamChat(
       text, persona, sessionId,
       (chunk) => {
@@ -247,6 +248,21 @@ export default function App() {
       false,
       undefined,
       attachments,
+      (q) => {
+        // ask_user 问答题：追加进流式状态（去重），ChatPage 渲染为选项卡片
+        // 重放可能带已解决/已过期的旧问题，先查状态只留 pending（失败则保留）
+        const a = streamAcc.current[sessionId]; if (!a) return;
+        if (a.questions.some((x) => x.id === q.id)) return;
+        void questionStatus([q.id]).then((st) => {
+          const s = st[q.id]?.status;
+          if (s && s !== 'pending') return;
+          const a2 = streamAcc.current[sessionId]; if (!a2) return;
+          if (a2.questions.some((x) => x.id === q.id)) return;
+          a2.questions.push(q);
+          setStreams((p) => (p[sessionId]
+            ? { ...p, [sessionId]: { ...p[sessionId], questions: [...a2.questions] } } : p));
+        });
+      },
     );
   }, [appendAssistant, clearStream]);
 
@@ -258,8 +274,8 @@ export default function App() {
     if (!last || last.role !== 'user') return;   // 没有悬空的用户消息 = 无需恢复
     let turnId = s.pendingTurnId;
     try { turnId = sessionStorage.getItem(`easel_pending_turn:${sessionId}`) || turnId; } catch { /* use persisted id */ }
-    streamAcc.current[sessionId] = { content: '', thinking: '', steps: [] };
-    setStreams((p) => ({ ...p, [sessionId]: { content: '', thinking: '', activity: '⏳ 正在接回上一轮结果…' } }));
+    streamAcc.current[sessionId] = { content: '', thinking: '', steps: [], questions: [] };
+    setStreams((p) => ({ ...p, [sessionId]: { content: '', thinking: '', activity: '⏳ 正在接回上一轮结果…', questions: [] } }));
     if (!turnId) {
       void fetchLastTurn(sessionId).then((r) => {
         if (r.status === 'done') appendAssistant(sessionId, { role: 'assistant', content: r.text || '（无输出）' });
@@ -316,6 +332,22 @@ export default function App() {
             role: 'assistant', content: '上一轮任务记录已失效，请重新发送上一条消息。',
           });
           clearStream(sessionId);
+        });
+      },
+      undefined,   // attachments: 恢复轮次无新附件
+      (q) => {
+        const a = streamAcc.current[sessionId]; if (!a) return;
+        if (a.questions.some((x) => x.id === q.id)) return;
+        // 重放可能带已解决/已过期的旧问题（gateway 15s 后即清理）——先查状态只留 pending；
+        // 查询失败时保留原样（宁显示不丢题）。
+        void questionStatus([q.id]).then((st) => {
+          const s = st[q.id]?.status;
+          if (s && s !== 'pending') return;   // answered/expired/cancelled/not_found：过滤
+          const a2 = streamAcc.current[sessionId]; if (!a2) return;
+          if (a2.questions.some((x) => x.id === q.id)) return;
+          a2.questions.push(q);
+          setStreams((p) => (p[sessionId]
+            ? { ...p, [sessionId]: { ...p[sessionId], questions: [...a2.questions] } } : p));
         });
       },
     );

--- a/web/frontend/src/components/ChatPage.tsx
+++ b/web/frontend/src/components/ChatPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import MessageBubble from './MessageBubble';
+import QuestionCards from './QuestionCards';
 import type { ChatSession, ChatMessage, StreamState } from '../lib/store';
 import { uploadFiles } from '../lib/api';
 import type { UploadedFile } from '../lib/api';
@@ -214,6 +215,9 @@ export default function ChatPage({ session, stream, onSend, onStop, onResend }: 
               />
             );
           })}
+          {isStreaming && (stream!.questions?.length ?? 0) > 0 && (
+            <QuestionCards questions={stream!.questions || []} />
+          )}
           <div ref={messagesEndRef} />
         </div>
       </div>

--- a/web/frontend/src/components/ChatPage.tsx
+++ b/web/frontend/src/components/ChatPage.tsx
@@ -17,6 +17,7 @@ interface ChatPageProps {
     attachments?: UploadedFile[],
     legacyAgentText?: string,
   ) => void; // 重试：仅对最后一轮
+  onQuestionAnswered?: (questionId: string) => void;   // 某道问答题提交成功（App 记录答过，重放不再出现）
 }
 
 // 空态推荐（贴合 Easel 社媒创作场景）
@@ -33,7 +34,7 @@ function greeting(): string {
   return `${g}，想创作点什么？`;
 }
 
-export default function ChatPage({ session, stream, onSend, onStop, onResend }: ChatPageProps) {
+export default function ChatPage({ session, stream, onSend, onStop, onResend, onQuestionAnswered }: ChatPageProps) {
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
@@ -216,7 +217,7 @@ export default function ChatPage({ session, stream, onSend, onStop, onResend }: 
             );
           })}
           {isStreaming && (stream!.questions?.length ?? 0) > 0 && (
-            <QuestionCards questions={stream!.questions || []} />
+            <QuestionCards questions={stream!.questions || []} onDone={(qid) => onQuestionAnswered?.(qid)} />
           )}
           <div ref={messagesEndRef} />
         </div>

--- a/web/frontend/src/components/QuestionCards.tsx
+++ b/web/frontend/src/components/QuestionCards.tsx
@@ -127,7 +127,7 @@ function QuestionCard({ question, onAnswered }: { question: ChatQuestion; onAnsw
 }
 
 /** 流式中的 ask_user 问答题列表（一次性卡片，答完即从当前流移除）。 */
-export default function QuestionCards({ questions }: { questions: ChatQuestion[] }) {
+export default function QuestionCards({ questions, onDone }: { questions: ChatQuestion[]; onDone?: (questionId: string) => void }) {
   const [answered, setAnswered] = useState<Record<string, boolean>>({});
   const visible = useMemo(
     () => questions.filter((q) => !answered[q.id]),
@@ -137,7 +137,10 @@ export default function QuestionCards({ questions }: { questions: ChatQuestion[]
   return (
     <>
       {visible.map((q) => (
-        <QuestionCard key={q.id} question={q} onAnswered={() => setAnswered((a) => ({ ...a, [q.id]: true }))} />
+        <QuestionCard key={q.id} question={q} onAnswered={() => {
+          setAnswered((a) => ({ ...a, [q.id]: true }));
+          onDone?.(q.id);   // 通知 App：此题已答，重放/恢复不再出现
+        }} />
       ))}
     </>
   );

--- a/web/frontend/src/components/QuestionCards.tsx
+++ b/web/frontend/src/components/QuestionCards.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react';
+import type { ChatQuestion, ChatQuestionItem } from '../lib/api';
+import { answerQuestion } from '../lib/api';
+
+/**
+ * ask_user 问答题卡片。
+ *
+ * OpenClaw 的 ask_user 一次可带 1-3 个问题（question.questions[]）。gateway 的
+ * question.resolve 要求 answers 里**每个问题都有答案**（单个缺失即报
+ * QUESTION_INVALID_ANSWER: "question 'xxx' requires an answer"）。
+ * 因此多问题时渲染全部题目，用户每问答完一项，全部选齐后自动提交一次。
+ */
+function QuestionCard({ question, onAnswered }: { question: ChatQuestion; onAnswered: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [selected, setSelected] = useState<Record<string, string>>({});
+  const [custom, setCustom] = useState<Record<string, string>>({});
+  const [showCustom, setShowCustom] = useState<Record<string, boolean>>({});
+
+  const items: ChatQuestionItem[] = question.questions || [];
+  const allAnswered = items.length > 0 && items.every((it) => (selected[it.questionId] || '').trim());
+
+  const submitSingle = async (it: ChatQuestionItem, label: string) => {
+    if (busy) return;
+    setBusy(true); setError('');
+    try {
+      const res = await answerQuestion({
+        questionId: question.id,
+        answers: { [it.questionId]: [label] },
+      });
+      if (!res.ok) setError(res.error || '提交失败');
+      else onAnswered();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitAll = async () => {
+    if (busy || !allAnswered) return;
+    setBusy(true); setError('');
+    const answers: Record<string, string[]> = {};
+    for (const it of items) {
+      answers[it.questionId] = [selected[it.questionId]];
+    }
+    try {
+      const res = await answerQuestion({ questionId: question.id, answers });
+      if (!res.ok) setError(res.error || '提交失败');
+      else onAnswered();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="message-row assistant">
+      <div className="msg-col assistant" style={{ maxWidth: '80%' }}>
+        <div className="question-card">
+          {items.map((it, idx) => {
+            const options: { label: string; description?: string }[] = it.options || [];
+            const val = selected[it.questionId] || '';
+            const ctl = showCustom[it.questionId];
+            return (
+              <div key={it.questionId} className="question-card__item">
+                {idx > 0 && <div className="question-card__divider" />}
+                {it.header && <div className="question-card__chip">{it.header}</div>}
+                <div className="question-card__title">{it.question || '请选择'}</div>
+                <div className="question-card__options">
+                  {options.map((opt) => (
+                    <button key={opt.label}
+                      className={`question-card__option${val === opt.label ? ' question-card__option--selected' : ''}`}
+                      disabled={busy}
+                      onClick={() => setSelected((s) => ({ ...s, [it.questionId]: opt.label }))}>
+                      <strong>{opt.label}</strong>
+                      {opt.description && <span>{opt.description}</span>}
+                    </button>
+                  ))}
+                  <button className="question-card__other" disabled={busy}
+                    onClick={() => setShowCustom((s) => ({ ...s, [it.questionId]: !s[it.questionId] }))}>
+                    {ctl ? '收起自定义输入' : '自行输入…'}
+                  </button>
+                </div>
+                {ctl && (
+                  <div className="question-card__custom">
+                    <input
+                      type="text"
+                      value={custom[it.questionId] || ''}
+                      placeholder="输入你的答案"
+                      onChange={(e) => setCustom((c) => ({ ...c, [it.questionId]: e.target.value }))}
+                    />
+                    <button disabled={busy || !(custom[it.questionId] || '').trim()}
+                      onClick={() => setSelected((s) => ({ ...s, [it.questionId]: custom[it.questionId].trim() }))}>
+                      填入
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {/* 单问题：选完即提交；多问题：全部选齐后自动提交 */}
+          {items.length === 1 ? (
+            <div className="question-card__actions">
+              <button className="question-card__submit" disabled={busy || !allAnswered}
+                onClick={() => void submitSingle(items[0], selected[items[0].questionId])}>
+                提交
+              </button>
+            </div>
+          ) : (
+            allAnswered && !busy && (
+              <div className="question-card__actions">
+                <button className="question-card__submit" disabled={busy} onClick={() => void submitAll()}>
+                  全部已选，提交
+                </button>
+              </div>
+            )
+          )}
+          {busy && <div className="question-card__hint">已提交，Agent 继续处理中…</div>}
+          {error && <div className="question-card__hint question-card__error">{error}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 流式中的 ask_user 问答题列表（一次性卡片，答完即从当前流移除）。 */
+export default function QuestionCards({ questions }: { questions: ChatQuestion[] }) {
+  const [answered, setAnswered] = useState<Record<string, boolean>>({});
+  const visible = useMemo(
+    () => questions.filter((q) => !answered[q.id]),
+    [questions, answered],
+  );
+  if (!visible.length) return null;
+  return (
+    <>
+      {visible.map((q) => (
+        <QuestionCard key={q.id} question={q} onAnswered={() => setAnswered((a) => ({ ...a, [q.id]: true }))} />
+      ))}
+    </>
+  );
+}

--- a/web/frontend/src/lib/api.ts
+++ b/web/frontend/src/lib/api.ts
@@ -294,6 +294,48 @@ export function deleteOutput(path: string): Promise<{ ok: boolean; deleted: stri
 }
 
 export interface UploadedFile { id: string; name: string; path: string; }
+
+/** OpenClaw ask_user 问答题（SSE question 事件 payload）。 */
+export interface ChatQuestionOption { label: string; description?: string; }
+export interface ChatQuestionItem {
+  questionId: string;
+  header?: string;
+  question: string;
+  options?: ChatQuestionOption[];
+  multiSelect?: boolean;
+}
+export interface ChatQuestion {
+  id: string;              // gateway question record id (ask_...)
+  questions: ChatQuestionItem[];
+  expiresAtMs?: number;
+}
+export async function answerQuestion(
+  payload: { questionId: string; answers: Record<string, string[]>; resolvedBy?: string },
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/api/chat/question/answer`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string };
+  return { ok: data.ok === true, error: data.error };
+}
+
+/** 批量查 question 状态：过滤重放中已解决/已过期的旧题。 */
+export async function questionStatus(
+  questionIds: string[],
+): Promise<Record<string, { status: string }>> {
+  if (!questionIds.length) return {};
+  try {
+    const res = await fetch(`${BASE}/api/chat/question/status`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ questionIds }),
+    });
+    const data = await res.json().catch(() => ({})) as { ok?: boolean; questions?: Record<string, { status: string }> };
+    return data.questions || {};
+  } catch {
+    return {};
+  }
+}
 /** 上传素材到当前会话的隔离 inbox，返回后端可校验的附件引用。 */
 export async function uploadFiles(files: File[], sessionId: string): Promise<UploadedFile[]> {
   const fd = new FormData();
@@ -468,6 +510,7 @@ export function streamChat(
   resumeOnly = false,
   onRecoveryUnavailable?: () => void,
   attachments: UploadedFile[] = [],
+  onQuestion?: (q: ChatQuestion) => void,
 ): AbortController {
   const controller = new AbortController();
   let lastEventId = 0;
@@ -502,6 +545,8 @@ export function streamChat(
           try { onThinking(JSON.parse(data) as string); } catch { onThinking(data); }
         } else if (currentEvent === 'activity' && onActivity) {
           try { onActivity(JSON.parse(data) as string); } catch { onActivity(data); }
+        } else if (currentEvent === 'question' && onQuestion) {
+          try { onQuestion(JSON.parse(data) as ChatQuestion); } catch { /* 解析失败忽略 */ }
         } else if (currentEvent === 'error') {
           let msg = '执行失败';
           try { msg = JSON.parse(data) as string; } catch { msg = data; }

--- a/web/frontend/src/lib/store.ts
+++ b/web/frontend/src/lib/store.ts
@@ -1,4 +1,4 @@
-import type { UploadedFile } from './api';
+import type { UploadedFile, ChatQuestion } from './api';
 
 export interface ChatMessage {
   role: 'user' | 'assistant';
@@ -25,6 +25,7 @@ export interface StreamState {
   content: string;
   thinking: string;
   activity: string;
+  questions: ChatQuestion[];   // ask_user 问答题卡片（进行中）
 }
 
 /** 发布中心草稿：持久化到 localStorage，切页/刷新都不丢。 */
@@ -111,21 +112,24 @@ export function loadSessions(): ChatSession[] {
   try {
     const raw = readMigratedLocalValue(STORAGE_KEY, 'sessions');
     if (!raw) return [];
-    const sessions = JSON.parse(raw) as ChatSession[];
+    const sessions = (JSON.parse(raw) as ChatSession[]).filter((s) => s && typeof s === 'object' && s.id);
     // 兼容旧版本：附件内部指令曾被直接存进用户消息，加载时拆出并隐藏。
+    // 防御：损坏/缺字段的会话（旧版写入或写中断）恢复成可用形态，绝不让渲染期崩。
     return sessions.map((session) => ({
       ...session,
-      messages: session.messages.map((message) => {
-        if (message.role !== 'user' || message.agentContent || !message.content.includes('【附件素材】')) {
-          return message;
-        }
-        const [visible = ''] = message.content.split('【附件素材】', 1);
-        return {
-          ...message,
-          content: visible.trim(),
-          agentContent: message.content,
-        };
-      }),
+      messages: Array.isArray(session.messages)
+        ? session.messages.map((message) => {
+            if (message?.role !== 'user' || message.agentContent || !message.content?.includes('【附件素材】')) {
+              return message;
+            }
+            const [visible = ''] = message.content.split('【附件素材】', 1);
+            return {
+              ...message,
+              content: visible.trim(),
+              agentContent: message.content,
+            };
+          })
+        : [],
     }));
   } catch {
     return [];
@@ -270,7 +274,8 @@ export function generateSessionTitle(message: string, _seed = message): string {
 }
 
 export function updateSessionTitle(session: ChatSession): void {
-  if (session.messages.length > 0 && session.title === 'New Chat') {
-    session.title = generateSessionTitle(session.messages[0].content, session.id);
+  const first = Array.isArray(session.messages) ? session.messages[0] : undefined;
+  if (first && session.title === 'New Chat') {
+    session.title = generateSessionTitle(first.content || '', session.id);
   }
 }

--- a/web/frontend/src/styles/index.css
+++ b/web/frontend/src/styles/index.css
@@ -425,6 +425,59 @@ textarea.field { resize: vertical; min-height: 90px; }
 .message-row.user { justify-content: flex-end; }
 .message-row.assistant { justify-content: flex-start; }
 
+/* ---- ask_user 问答题卡片（OpenClaw question RPC 桥接） ---- */
+.question-card {
+  background: var(--bg-elevated, #fff); border: 1px solid var(--border, rgba(0,0,0,.08));
+  border-radius: var(--radius-lg, 14px); padding: 14px 16px;
+  box-shadow: 0 3px 14px rgba(23,25,28,.06);
+  display: grid; gap: 10px; width: 100%;
+  animation: fadeIn 0.24s var(--ease);
+}
+.question-card__chip {
+  justify-self: start; padding: 3px 9px; border-radius: var(--radius-full, 999px);
+  background: var(--accent-start, #4361ee); color: #fff;
+  font-size: 11px; font-weight: 650; letter-spacing: .05em; text-transform: uppercase;
+}
+.question-card__title { color: var(--text-strong, #20242c); font-size: 15px; font-weight: 650; line-height: 1.4; }
+.question-card__options { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; }
+.question-card__option {
+  display: grid; gap: 3px; text-align: left; padding: 11px 12px; cursor: pointer;
+  border: 1px solid var(--border, rgba(0,0,0,.12)); border-radius: var(--radius-lg, 12px);
+  background: var(--bg, #fff); font: inherit; transition: border-color .16s var(--ease), box-shadow .16s var(--ease);
+}
+.question-card__option:hover:not(:disabled) { border-color: var(--accent-start, #4361ee); box-shadow: 0 2px 8px rgba(67,97,238,.14); }
+.question-card__option--selected { border-color: var(--accent-start, #4361ee); background: color-mix(in srgb, var(--accent-start, #4361ee) 10%, #fff); }
+.question-card__option:disabled { opacity: .55; cursor: default; }
+.question-card__option strong { color: var(--text-strong, #20242c); font-size: 14px; }
+.question-card__option span { color: var(--text-secondary, #666); font-size: 12px; line-height: 1.45; }
+.question-card__other {
+  justify-self: start; background: none; border: 0; padding: 4px 2px; cursor: pointer;
+  color: var(--accent-start, #4361ee); font-size: 12px; text-decoration: underline;
+}
+.question-card__other:disabled { opacity: .55; cursor: default; }
+.question-card__custom { display: flex; gap: 8px; }
+.question-card__custom input {
+  flex: 1; padding: 9px 12px; border-radius: var(--radius, 10px);
+  border: 1px solid var(--border, rgba(0,0,0,.12)); font: inherit; font-size: 13px;
+}
+.question-card__custom input:focus { outline: 2px solid var(--accent-start, #4361ee); outline-offset: 1px; }
+.question-card__custom button {
+  padding: 9px 16px; border-radius: var(--radius, 10px); border: 0; cursor: pointer;
+  background: var(--accent-start, #4361ee); color: #fff; font-weight: 600;
+}
+.question-card__custom button:disabled { opacity: .5; cursor: default; }
+.question-card__hint { color: var(--text-secondary, #666); font-size: 12px; }
+.question-card__error { color: #c0392b; }
+.question-card__item { display: grid; gap: 8px; }
+.question-card__divider { height: 1px; background: var(--border, rgba(0,0,0,.08)); margin: 10px 0; }
+.question-card__actions { display: flex; justify-content: flex-end; }
+.question-card__submit {
+  padding: 9px 20px; border-radius: var(--radius, 10px); border: 0; cursor: pointer;
+  background: var(--accent-start, #4361ee); color: #fff; font-weight: 600;
+}
+.question-card__submit:disabled { opacity: .5; cursor: default; }
+
+
 .message-bubble {
   max-width: 74%; padding: 12px 16px;
   border-radius: var(--radius-lg); font-size: 14px; line-height: 1.65;


### PR DESCRIPTION
## 问题

Easel 自研的 React 聊天前端从未消费 OpenClaw 的 `ask_user` 问题 RPC。agent 调用 `ask_user` 时，结构化问题（选项、多选、自定义输入）在本地 gateway 进程中注册了，但**从未显示到网页聊天里**——agent 一直阻塞到超时，用户只看到一个"仍在处理中"的转圈，最后拿到 `no_answer`。

这让平台在真实流程里显得"卡死"：agent 问今天想发什么内容，用户根本看不到选项，运行在无声中超时。

## 改动内容

### Gateway 桥（`easel/gateway_questions.py`，新增）
一个极简的 Gateway WebSocket RPC 客户端，以已配对的本地设备身份连接（Ed25519 v2 签名 payload，设备身份从 OpenClaw state DB 读取）。暴露 `list_questions()` / `get_question()` / `resolve_question()`。

### Web 后端（`web/app.py`）
- agent 运行期间，聊天流 supervisor 每 2 秒轮询一次该会话的 `question.list`，把新的待答问题以 SSE `question` 事件推送出去。
- 新增 `POST /api/chat/question/answer`，把答案转发给 `question.resolve`。
- 新增 `POST /api/chat/question/status`，供前端批量查询问题状态（用于重放时过滤过期事件）。

### 前端
- `components/QuestionCards.tsx`（新增）：把 `ask_user` payload 里的**每一道题**（1-3 题）渲染成可选卡片，每题都支持自定义输入。多题 payload 必须**全部作答**才可提交——`question.resolve` 会拒绝缺答（`QUESTION_INVALID_ANSWER`）。
- `lib/api.ts` / `lib/store.ts`：`ChatQuestion` 类型、`answerQuestion()`、`questionStatus()`、流上的 `onQuestion` 回调、流状态里的 `questions`。
- `App.tsx`：累计 question 事件（去重）、按状态过滤重放事件（只保留 `pending`）、把已答问题从流状态中移除、记录已答 id，保证已解决的问题在刷新、切换会话或恢复挂起 turn 后不再重现。
- `ChatPage.tsx`：流式输出期间渲染 `QuestionCards`。

### Windows 运行修复（同分支，小改）
- `easel/openclaw_cmd.py`（新增）+ `ping.py`/`skill.py`：改为通过 `node + openclaw.mjs` 调起 OpenClaw CLI，而不是 `.cmd` shim——Windows 的 `CreateProcess` 无法直接运行 `.cmd`，且 `cmd /c` 包装会把多行消息截断。
- `setup.ps1`：单元素 models 数组改用 `ConvertTo-Json -AsArray`（OpenClaw 校验要求真数组；单个元素不加 `-AsArray` 会被序列化成对象导致校验失败）。

## 已验证

Windows 真机 + 真实 gateway 端到端验证：
- ask_user 各轮渲染出多张问题卡片（单题、多题均已验证）。
- 全部作答后一次提交，agent 继续；缺答时返回 gateway 错误、卡片保留。
- 重放已完成的 turn（刷新 / 恢复挂起 turn）不再复活已答卡片。
- 切换会话再切回，已答卡片不会重新挂载。
- Windows 上重跑 / 全新安装流程通过基于 node 的 launcher。

## 跨平台验证（2026-09-11 更新）

Linux（Ubuntu 26.04 / WSL2）全链路验证通过：
- `easel ping` 两步全过；`easel web` + `ask_user` 全链路通过（question 事件 → 作答 → `answered` → `done` → agent 继续产出）；分支上 `pytest`：100 passed / 5 skipped。
- 验证中发现并修复 3 处跨平台问题（已包含在本分支）：`cc04d24` 补全客户端身份（platform + deviceFamily）、`6204ee0` cli chat→tui、`3a196d5` question 桥接错误日志。
- macOS 无实机验证（手头没有 Mac 设备；darwin→macos 路径按官方客户端行为实现）。

细节、截图与验证脚本见 [本 PR 评论](#issuecomment-5622192101) 及 fork 的 `pr8-evidence` 分支。

## 测试步骤

启动 gateway 和 web（`easel gateway`、`easel web`），打开聊天，发一条会让 agent 调用 `ask_user` 的消息（比如"用工具问我问题"）。选项卡片应出现；选一个选项（或自己输入）后 agent 继续。
