### PR TITLE
feat(douyin): readback verification, human pacing, SMS wall handling & direct-connect

### DIFF
--- a/skills/openclaw/skill-douyin-upload/SKILL.md
+++ b/skills/openclaw/skill-douyin-upload/SKILL.md
@@ -43,7 +43,7 @@ check（环境就绪？）
   → 发布前人设检查（见下）
   → publish / publish-video --exec（首次建议 --headed 校验选择器，OK 后 headless 复跑）
   → 【若弹短信墙】问用户验证码 → 回填 → 脚本自动过墙（见「短信验证码处理」）
-  → 成功校验（脚本内置：发布后 toast「发布成功」）
+  → 成功校验（脚本内置：发布后**读回创作者中心作品列表对账**——标题+时间窗对上该作品才算 success）
   → 发布后留痕（见下）
 ```
 
@@ -55,20 +55,33 @@ check（环境就绪？）
 
 1. **后台**启动发布（务必带 `--status-file` 和 `--sms-code-file`，路径用 `outputs/_login/` 下）：
    ```bash
-   python skills/shared/scripts/douyin_publish.py publish-video --exec \
+   python skills/shared/scripts/douyin_publish.py publish-video --exec --no-proxy \
      --title "标题" --content "简介" --video /abs/v.mp4 --tags "旅行,攻略" \
      --status-file outputs/_login/douyin.publish.json \
      --sms-code-file outputs/_login/douyin.code
    ```
-2. **轮询** `outputs/_login/douyin.publish.json`（JSON，字段 `state`：`starting`→可能 `sms_required`→`verifying`→`success`/`error`）。
-3. 读到 `state=="sms_required"`：把该文件里的 `message`（含发码手机尾号）转达用户，**在对话里向用户要验证码**。
+2. **轮询**（**每 2–3 秒查一次，用短命令循环**——别一次性长睡眠干等，墙一出现你才能立刻反应）：
+   ```bash
+   sleep 3; cat outputs/_login/douyin.publish.json
+   ```
+   状态机（JSON 字段 `state`）：`starting`→可能 `sms_required`→`verifying`→`success`/`error`。**`success` 只在发布后读回创作者中心作品列表、对账通过才写入**，message 里带核验到的作品 id 与状态；读回没对上落 `error`，message 区分三种：登录态失效（需重新登录）/ 列表暂未见本次内容（需到内容管理页人工核对）/ 读回通道异常。
+3. 读到 `state=="sms_required"`（含『正在发送验证码』阶段——**看到就立即弹，不必等短信到**）：**马上调用 `ask_user` 工具弹【验证码卡片】要码——不要用普通文字消息**（文字没有输入框、容易被错过；卡片自带「自行输入…」填空，用户填完提交你直接拿到数字）。参数模板（`options` 必需 2–4 个；验证码本身走卡片自带的自由输入）：
+   ```json
+   {"questions":[{"id":"sms_code","header":"发布验证","question":"抖音发布触发短信验证：请把手机收到的 6 位验证码填进来（点「自行输入…」后输入数字）。","options":[{"label":"重新发送验证码"},{"label":"取消本次发布"}]}],"timeoutSeconds":300}
+   ```
+   用户提交后按答案分流：
+   - **纯数字（4–8 位）** → 进第 4 步写码文件；
+   - **「重新发送验证码」** → 创建重发信号文件（`printf '' > outputs/_login/douyin.code.resend` 或 `touch outputs/_login/douyin.code.resend`）；脚本收到信号会在墙上点「重新发送」再下发 → **立刻再弹一张卡**（问题改为「已重发——把新收到的验证码填进来；仍未收到就选『还是没收到』，稍后我再重试」）；
+   - **「取消本次发布」** → 告知用户脚本会自行超时退出（或等他确认后收尾）。
 4. 拿到验证码后，把**纯数字**写进码文件（一次性消费，脚本读走即删）：
    ```bash
    printf '%s' "123456" > outputs/_login/douyin.code
    ```
 5. 继续轮询直到 `success`/`error`。码错会退回 `sms_required`，可再要一次重写。
 
-要点：验证码文件内容是纯数字（4–8 位）；不要同步前台阻塞跑发布再想中途问用户（Bash 会一直卡住直到脚本退出）。发布页（Web「发布中心」）已用同一套文件协议自动弹框，无需 agent 介入。
+要点：验证码文件内容是纯数字（4–8 位）；**全程保持"后台脚本 + 短轮询"模式**——不要同步前台阻塞跑发布再想中途问用户（Bash 会一直卡住直到脚本退出）。发布页（Web「发布中心」）已用同一套文件协议自动弹框，无需 agent 介入。
+
+**速度要点（决定成败）**：墙出现 → 脚本识别（≤15s）→ 你读到 `sms_required` → **数秒内**弹出卡片（所以轮询别用长 sleep；读到就弹，别先解释）→ 用户提交 → **立即**写码文件（一条 `printf` 的事，不拖）。任何环节拖 30 秒以上，用户手机上的验证码就可能过期要重发。
 
 ## 发布前人设检查（有 Profile 时）
 

--- a/skills/shared/scripts/douyin_publish.py
+++ b/skills/shared/scripts/douyin_publish.py
@@ -10,7 +10,7 @@ WJZ-P/douyin-upload-mcp-skill（src/douyin-ops.js）。确定性 IO 在脚本，
   - 切 tab（发布视频/发布图文）→ 隐藏 file input 塞文件
   - 视频等 uploading-container 消失（≤5min）→ 等 AI 封面（≤60s）选推荐封面
   - 标题 input[placeholder*=作品标题]；简介 slate contenteditable（Ctrl+A 清空再输）
-  - 发布按钮在 card-container-creator-layout 内文本「发布」→ toast 校验「发布成功」
+  - 发布按钮在 card-container-creator-layout 内文本「发布」→ 发布后读回创作者中心作品列表对账（platform_readback；标题+时间窗对上才算成功）
   - 登录：img[aria-label=二维码] 抠图轮询；命中短信验证给提示
 
 子命令: check / login / plan / publish / publish-video / selftest
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import sys
 import time
 from pathlib import Path
@@ -28,6 +29,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import login_state  # noqa: E402
 import content_guard  # noqa: E402  出站内容安全闸门
+import platform_readback  # noqa: E402  发布读回对账（快照+列表对账协议）
+import human_pace  # noqa: E402  人类节奏（分档随机停顿）
 
 HOME_URL = "https://creator.douyin.com/"
 TITLE_MAX = 30  # 抖音作品标题上限（字符）
@@ -86,7 +89,12 @@ SMS_ERROR_TEXTS = ("验证码错误", "验证码填写错误", "验证码输入�
 # 必须把找输入框/按钮/手机号/错误文案都**限定在这个弹窗内**，否则 query_selector 会取到
 # DOM 顺序在前的背景框，导致码打进没用的框、弹窗框空着（真机实测的坑，见截图）。
 SMS_MODAL_SELS = ("[class*='semi-modal-content']", "[class*='semi-modal']",
-                  "div[role='dialog']", "[class*='modal-content']", "[class*='dialog']")
+                  "div[role='dialog']", "[class*='modal-content']", "[class*='dialog']",
+                  # 发布风控墙（2026-09-12 真机 dump 校准）：second_verify_panel / second-verify-mask 双形态
+                  "[class*='second_verify_panel']", "[class*='second-verify-panel']",
+                  "[class*='second_verify_mask']", "[class*='second-verify-mask']",
+                  # 通用身份验证弹窗（多种 class 形态容错）
+                  "[data-e2e='verification-dialog']", "[data-testid='verification-dialog']")
 # 判「真正出现了身份验证/短信墙」的文案——**只认弹窗里的这些词**，不认背景『验证码登录』表单
 # （它也有验证码框但不是风控墙）。没命中=不需要短信验证，别硬跳短信流程（实事求是）。
 WALL_KEYWORDS = ("身份验证", "接收短信", "短信验证", "验证方式", "短信已发送",
@@ -142,10 +150,33 @@ def _proxy(explicit: str | None, disable: bool) -> str | None:
 def _launch(p, headed: bool, base: str | None, proxy: str | None):
     profile = _profile_dir(base)
     profile.mkdir(parents=True, exist_ok=True)
-    kwargs = dict(headless=not headed, locale="zh-CN", args=LAUNCH_ARGS)
+    args = list(LAUNCH_ARGS)
+    if not proxy:
+        # 显式直连：忽略环境里可能存在的 http_proxy/https_proxy
+        #（国内平台发布/登录必须直连；web 侧 _proxy_env 可能注入代理变量，这里兜底）
+        args.append("--no-proxy-server")
+    kwargs = dict(headless=not headed, locale="zh-CN", args=args)
     if proxy:
         kwargs["proxy"] = {"server": proxy}
     return p.chromium.launch_persistent_context(str(profile), **kwargs)
+
+
+def _wait_ready(page, timeout_ms: int = 15000) -> None:
+    """等首页 SPA 跳转并渲染出「登录判定元素」（发布按钮或二维码）——goto 裸域名后页面会
+    从 `creator.douyin.com/` 跳到 `creator-micro/home`，跳转期间 DOM 还没渲染，过早 query 会把
+    已登录误判成未登录（真机实测：只 wait 1.5s 时 hd_publish 找不到 → 误报『未登录』）。
+    轮询直到 hd_publish 或 qrcode 出现，或超时（超时后仍交给 _logged_in 判定，不在此处 _die）。"""
+    deadline = time.time() + timeout_ms / 1000
+    while time.time() < deadline:
+        try:
+            if page.query_selector(SELECTORS["hd_publish"]) or page.query_selector(SELECTORS["qrcode"]):
+                return
+        except Exception:
+            pass
+        try:
+            page.wait_for_timeout(500)
+        except Exception:
+            return
 
 
 def _logged_in(page) -> bool:
@@ -247,15 +278,17 @@ def _refresh_qr_if_expired(page) -> bool:
     return False
 
 
-def _human_type(page, el, text: str) -> None:
-    """聚焦→Ctrl+A 清空→逐字输入（REF fillTitle/fillDescription）。"""
+def _human_type(page, el, text: str, delay_ms: tuple[int, int] | None = None) -> None:
+    """聚焦→Ctrl+A 清空→逐字输入（REF fillTitle/fillDescription）。
+    delay_ms=(lo, hi) 时逐字随机延迟（逐字随机 65~140ms，更像手打）；
+    默认 None 保持登录等场景的快速输入。"""
     el.click()
     page.wait_for_timeout(200)
     page.keyboard.press("Control+a")
     page.keyboard.press("Delete")
     for ch in text:
         page.keyboard.type(ch)
-        page.wait_for_timeout(15)
+        page.wait_for_timeout(random.randint(*delay_ms) if delay_ms else 15)
 
 
 def _go_upload(page):
@@ -295,16 +328,41 @@ def _upload_files(page, paths: list[str]):
     page.wait_for_timeout(1000)
 
 
-def _wait_video_processed(page, timeout_s: int = 300):
-    """等上传/转码完成 + 编辑器就绪。小文件秒传时 uploading-container 可能还没出现就返回=假就绪
-    （真机实测：标题框还没渲染就去填→找不到）。改为**正向等标题输入框出现**（编辑页
-    content/post/video 渲染完成的标志），再等上传条彻底消失。"""
+def _wait_video_processed(page, timeout_s: int = 480):
+    """等上传/转码完成 + 编辑器就绪。编辑页（content/post/video）渲染完成、标题输入框可交互
+    即视为基线就绪信号，不依赖 uploading 进度条元素是否存在：真机实测（2026-09）编辑页存在
+    class 含 'uploading-container' 的**常驻**元素，若把『uploading 消失』当作就绪条件会死等到
+    超时（曾卡 300s）。仅当标题框已出现但仍检测到**可见**的 uploading 条时才继续等。
+
+    稳定性增强：就绪需**连续两次**检查通过（间隔 2s），
+    防瞬时假就绪；页面出现 role=progressbar 且带 aria-valuenow 时要求 >= 100。"""
     deadline = time.time() + timeout_s
+    stable = 0
     while time.time() < deadline:
-        if page.query_selector(SELECTORS["title_input"]) and not page.query_selector(SELECTORS["uploading"]):
-            page.wait_for_timeout(1200)   # 编辑器完全可交互
+        ok = False
+        ti = page.query_selector(SELECTORS["title_input"])
+        if ti and ti.is_visible():
+            up = page.query_selector(SELECTORS["uploading"])
+            # 只要上传条不可见（或不存在）就认为上传已完成，避免匹配到常驻隐藏元素而空等
+            if not up or not up.is_visible():
+                ok = True
+                # role=progressbar 存在时加验进度值（拿不到就当通过，不误伤）
+                try:
+                    pb = page.query_selector('[role="progressbar"]')
+                except Exception:
+                    pb = None
+                if pb is not None:
+                    try:
+                        val = pb.get_attribute("aria-valuenow")
+                        if val is not None and float(val) < 100:
+                            ok = False
+                    except Exception:
+                        pass
+        stable = stable + 1 if ok else 0
+        if stable >= 2:                       # 连续两次就绪 → 稳定，放行
+            page.wait_for_timeout(1200)       # 编辑器完全可交互
             return
-        page.wait_for_timeout(1500)
+        page.wait_for_timeout(2000)
     _die(f"视频上传/转码超时或编辑器未就绪（{timeout_s}s）")
 
 
@@ -333,32 +391,60 @@ def _fill_title_desc(page, title: str, desc: str, tags: list[str]):
     ti = page.query_selector(SELECTORS["title_input"])
     if not ti:
         _die("未找到标题输入框（检查 SELECTORS.title_input）")
-    _human_type(page, ti, title)
-    page.wait_for_timeout(300)
+    _human_type(page, ti, title, delay_ms=(65, 140))     # 随机打字节奏
+    human_pace.pace("field-switch")                      # 标题→简介的自然切换停顿
     # 抖音话题写进简介正文（# 自动联想成话题）
     body = desc or ""
     if tags:
         body = (body + " " + " ".join("#" + t.lstrip("#") for t in tags)).strip()
     di = page.query_selector(SELECTORS["desc_input"])
     if di and body:
-        _human_type(page, di, body)
-        page.wait_for_timeout(300)
+        _human_type(page, di, body, delay_ms=(65, 140))
+    page.wait_for_timeout(300)
 
 
-def _click_publish(page):
-    """在 card-container-creator-layout 内点文本为「发布」的按钮。REF publishVideo step8。"""
+def _find_publish_button(page):
+    """在 card-container-creator-layout 内找文本为「发布」的按钮（返回句柄或 None）。"""
     container = page.query_selector(SELECTORS["publish_container"])
     scope = container or page
-    btn = None
     for b in scope.query_selector_all("button"):
         try:
             if (b.inner_text() or "").strip() == "发布" and b.is_visible():
-                btn = b
-                break
+                return b
         except Exception:
             continue
-    if not btn:
-        _die("未找到发布按钮（card-container 内文本『发布』）")
+    return None
+
+
+def _wait_publish_button_ready(page, timeout_s: int = 180):
+    """等「发布」按钮进入可提交稳态（提交前独立收敛阶段，绝不在按钮未就绪时点——
+    防「点了但没生效」的静默假提交）。就绪 = 按钮可见 + 非 disabled/aria-disabled，且**连续两次**
+    检查通过（间隔 1.5s）。超时按未提交处理并 dump 现场。"""
+    deadline = time.time() + timeout_s
+    stable = 0
+    while time.time() < deadline:
+        btn = _find_publish_button(page)
+        ok = False
+        if btn is not None:
+            try:
+                dis = btn.get_attribute("disabled")
+                aria = btn.get_attribute("aria-disabled")
+                ok = (dis is None) and (aria not in ("true", "1"))
+            except Exception:
+                ok = False
+        stable = stable + 1 if ok else 0
+        if stable >= 2:
+            return btn
+        page.wait_for_timeout(1500)
+    _dump_publish_fail(page, "publish-button-not-ready")
+    _die(f"发布按钮迟迟未就绪（上传未完成/表单校验未过），已按未提交处理（{timeout_s}s）")
+
+
+def _click_publish(page, content_length: int = 0):
+    """单次提交契约：整个发布流程**唯一一次**点击「发布」。
+    点前等按钮就绪 → 复核/提交双停顿 → 点击。REF publishVideo step8。"""
+    btn = _wait_publish_button_ready(page)
+    human_pace.pause_before_commit(content_length)
     btn.scroll_into_view_if_needed()
     page.wait_for_timeout(300)
     btn.click()
@@ -439,9 +525,17 @@ def _handle_publish_sms_inner(page, code_file: Path, sf, wait_s: int) -> bool:
     login_state.write_status(sf, "sms_required", msg)
     print(f"📩 {msg}——等待回填 {code_file}（≤{wait_s}s，可多次重输）", file=sys.stderr)
     deadline = time.time() + wait_s
+    resend_file = Path(str(code_file) + ".resend")
     while time.time() < deadline:
         if _publish_verified(page):                          # 墙没了/已跳转 = 验证已过（或平台直接放行）
             return True
+        if resend_file.exists():                             # 请求重发信号（一次性）：点「重新发送」再下发
+            try:
+                resend_file.unlink()
+            except OSError:
+                pass
+            if _sms_click_first(page, SMS_SEND_OPTS):
+                print("📨 已按请求重新发送验证码", file=sys.stderr)
         code = login_state.read_sms_code(str(code_file))
         if not code:
             page.wait_for_timeout(1500)
@@ -987,7 +1081,7 @@ def _plan_lines(kind, title, desc, media, tags):
         f"  2. 切 tab「{tab}」",
         f"  3. {'上传视频等转码(≤5min)+选AI封面' if kind == 'video' else '上传图片'}",
         "  4. 填标题/简介（Ctrl+A 清空再逐字输入）+ # 话题",
-        "  5. 点「发布」→ toast 校验「发布成功」",
+        "  5. 点「发布」→ 发布后读回作品列表对账（标题+时间窗对上才算发布成功）",
     ]
 
 
@@ -1001,12 +1095,14 @@ def cmd_plan(a) -> int:
     return 0
 
 
-def _verify_published(p, a, title: str) -> bool:
-    """重开一个干净 context 查内容管理页，确认标题对应作品是否已发布/审核中（权威判定）。
-    发布收尾偶发渲染进程崩溃（"Page crashed"）但作品其实已提交成功——崩溃后用它核验，避免误报失败。"""
-    key = (title or "").strip()[:12]
-    if not key:
-        return False
+def _readback_verify(p, a, title: str, since_ms: int | None = None,
+                     snapshot_ids: set[str] | None = None):
+    """重开一个干净 context 读回创作者中心作品列表，与本次发布对账（权威判定）。
+
+    发布收尾偶发渲染进程崩溃（"Page crashed"）但作品其实已提交成功——崩溃后用它核验，
+    避免误报失败。对账协议见 platform_readback。
+    返回 platform_readback.ReadbackResult（outcome: verified/unverified/login_required/readback_error）；不抛异常。
+    """
     try:
         ctx = _launch(p, headed=False, base=a.profile_base, proxy=_proxy(a.proxy, a.no_proxy))
         page = ctx.pages[0] if ctx.pages else ctx.new_page()
@@ -1014,20 +1110,18 @@ def _verify_published(p, a, title: str) -> bool:
             page.set_default_timeout(30000)
             page.goto("https://creator.douyin.com/creator-micro/content/manage",
                       wait_until="domcontentloaded")
-            page.wait_for_timeout(6000)     # 作品列表异步渲染
-            body = page.inner_text("body") or ""
-            found = key in body
-            print(f"{'✅ 核验：内容管理页已见该作品' if found else '❌ 核验：内容管理页未见该作品'}（key={key}）",
-                  file=sys.stderr)
-            return found
+            page.wait_for_timeout(3000)     # 页面上下文稳定后再发页内请求
+            return platform_readback.verify_douyin_publish(
+                page, title=title, since_ms=since_ms, limit=20, attempts=3, delay_s=10,
+                snapshot_ids=snapshot_ids)
         finally:
             try:
                 ctx.close()
             except Exception:
                 pass
     except Exception as e:  # noqa: BLE001
-        print(f"⚠️ 重开核验失败：{e}", file=sys.stderr)
-        return False
+        print(f"⚠️ 重开读回核验失败：{e}", file=sys.stderr)
+        return platform_readback.ReadbackResult(outcome="readback_error", error=str(e))
 
 
 def _publish(a, kind: str) -> int:
@@ -1063,27 +1157,41 @@ def _publish(a, kind: str) -> int:
         _die(f"需要 playwright：{e}", 3)
     sf = getattr(a, "status_file", None)
     login_state.write_status(sf, "starting", "发布中…")
-    published = None   # None=未确认（崩溃/超时→重开核验）；True/False=已判定
+    started_ms = int(time.time() * 1000)
+    published = None   # None=未确认（崩溃/超时→重开核验）；True/False=界面层已判定
+    readback = None    # 读回对账（权威判定）：platform_readback.ReadbackResult
+    snapshot_ids: set[str] = set()   # 发前快照（发布前作品 id 集；发布动作前在页面里抓）
     with sync_playwright() as p:
         ctx = _launch(p, headed=a.headed, base=a.profile_base, proxy=_proxy(a.proxy, a.no_proxy))
         page = ctx.pages[0] if ctx.pages else ctx.new_page()
         page.set_default_timeout(300000)
         try:
             page.goto(HOME_URL, wait_until="domcontentloaded")
-            page.wait_for_timeout(1500)
+            _wait_ready(page)
             if not _logged_in(page):
                 _die("未登录，请先 `login` 扫码")
+            # 发前快照：记录当前作品 id 集，读回时用于排除旧作品
+            snapshot_ids = platform_readback.capture_douyin_snapshot(page)
             _go_upload(page)
+            human_pace.pace("task-switch")               # 进编辑器的自然停顿
             _switch_tab(page, "video" if kind == "video" else "imagetext")
             _upload_files(page, media)
+            human_pace.pace("field-switch")              # 上传后到填写前
             if kind == "video":
                 _wait_video_processed(page)
                 _select_ai_cover(page)
             _fill_title_desc(page, a.title, a.content or "", tags)
-            _click_publish(page)
-            page.wait_for_timeout(2500)
+            _click_publish(page, len(a.title) + len(a.content or ""))
+            # 点击后轮询等风控墙浮现（2026-09-12 真机发现：墙的渲染晚于 2.5s，
+            # 单次检查会扑空 → 漏进收尾 → 对着被墙遮挡的按钮空点超时。≤12s 窗口）
+            wall_up = False
+            for _ in range(6):
+                page.wait_for_timeout(2000)
+                if _verify_wall(page):
+                    wall_up = True
+                    break
             # 发布也可能触发风控短信验证墙（真机实测：点发布后弹「接收短信验证码」）
-            if _verify_wall(page):
+            if wall_up:
                 code_file = (Path(a.sms_code_file).expanduser()
                              if getattr(a, "sms_code_file", None)
                              else DEFAULT_QR_OUT.parent / "douyin.code")
@@ -1095,16 +1203,36 @@ def _publish(a, kind: str) -> int:
             if published is None:
                 try:
                     page.wait_for_timeout(1500)
-                    if "post/video" in page.url or "post/image" in page.url:
-                        try:
-                            _click_publish(page)
-                        except SystemExit:
-                            pass
-                    _wait_toast(page, timeout_s=40)
-                    published = True
+                    if _verify_wall(page):
+                        # 收尾阶段才发现墙（渲染更晚）——立即进短信流程，绝不对着墙空点
+                        code_file = (Path(a.sms_code_file).expanduser()
+                                     if getattr(a, "sms_code_file", None)
+                                     else DEFAULT_QR_OUT.parent / "douyin.code")
+                        if not _handle_publish_sms(page, code_file, sf):
+                            _dump_publish_fail(page, "publish-sms-fail")
+                            published = False
+                    if published is None:
+                        if "post/video" in page.url or "post/image" in page.url:
+                            try:
+                                _click_publish(page)
+                            except SystemExit:
+                                pass
+                        _wait_toast(page, timeout_s=40)
+                        published = True
                 except (PWTimeout, PWError, SystemExit) as e:
-                    print(f"⚠️ 收尾阶段异常（{type(e).__name__}）——将重开浏览器核验是否已发布", file=sys.stderr)
+                    print(f"⚠️ 收尾阶段异常（{type(e).__name__}）——将读回作品列表核验", file=sys.stderr)
+                    _dump_publish_fail(page, "tail-anomaly")   # 点击后现场留档（诊断「发布未跳转」）
                     published = None
+            # 读回对账（权威判定）：界面判定只说明「提交动作被接受」，以平台侧作品列表为准。
+            if not a.keep_open and readback is None:
+                try:
+                    readback = platform_readback.verify_douyin_publish(
+                        page, title=a.title, since_ms=started_ms,
+                        limit=20, attempts=3, delay_s=10,
+                        snapshot_ids=snapshot_ids)
+                except Exception as e:  # noqa: BLE001
+                    print(f"⚠️ 就地读回失败（将重开核验）：{e}", file=sys.stderr)
+                    readback = None
         except PWTimeout:
             _dump_publish_fail(page, "publish-timeout")
             published = None
@@ -1117,12 +1245,19 @@ def _publish(a, kind: str) -> int:
                     ctx.close()
             except Exception:
                 pass
-        # 未确认（崩溃/超时）→ 重开一个干净 context 查内容管理页，确认到底发出去没有
-        if published is None:
-            published = _verify_published(p, a, a.title)
-    if published:
-        login_state.write_status(sf, "success", "发布成功")
-        print("✅ 抖音发布成功")
+        # 就地读回没拿到结论（崩溃/超时/通道错）→ 重开干净 context 读回核验
+        if readback is None or readback.outcome == "readback_error":
+            readback = _readback_verify(p, a, a.title, since_ms=started_ms,
+                                        snapshot_ids=snapshot_ids)
+    # 结算：以读回对账为权威（四档），界面判定仅作旁证。
+    outcome = readback.outcome if readback else "readback_error"
+    if outcome == "verified":
+        m = readback.matched
+        _acct = (readback.evidence or {}).get("account") or {}
+        _who = f"；账号：{_acct.get('display_name')}" if _acct.get("display_name") else ""
+        login_state.write_status(sf, "success",
+                                 f"发布成功（读回核验：作品 {m.platform_content_id}，{m.status}{_who}）")
+        print(f"✅ 抖音发布成功（读回核验：{m.platform_content_id}{_who}）")
         # 落统一内容日历（对话页自动；发布页由 web 设 AUTORECORD=0 跳过防重复）
         try:
             import calendar_ops
@@ -1132,8 +1267,18 @@ def _publish(a, kind: str) -> int:
         except Exception:
             pass
         return 0
-    login_state.write_status(sf, "error", "发布未确认成功（见 outputs/_login/douyin-publish-fail.* 或内容管理页）")
-    _die("发布未确认成功（内容管理页未见该作品；见截图/日志）", 5)
+    if outcome == "login_required":
+        login_state.write_status(sf, "error",
+                                 "发布未核验：读回时登录态已失效——请重新登录后到内容管理页核对是否已发出")
+        _die("读回核验时登录态已失效；请重新登录后核对内容管理页", 6)
+    if outcome == "unverified":
+        login_state.write_status(sf, "error",
+                                 "发布未确认：界面已操作完成，但读回作品列表未见本次内容（可能仍在索引/审核，或未真正发出）——请到内容管理页核对")
+        _die("发布未确认：读回作品列表未见本次内容（见内容管理页）", 5)
+    reason = getattr(readback, "error", None) or "读回通道异常"
+    login_state.write_status(sf, "error",
+                             f"发布未确认成功（{reason}；见 outputs/_login/douyin-publish-fail.* 或内容管理页）")
+    _die(f"发布未确认成功（{reason}；见截图/日志）", 5)
 
 
 def cmd_publish(a) -> int:
@@ -1227,12 +1372,36 @@ def cmd_selftest(_a) -> int:
     assert "verifying" in login_state.STATES
     # 短信多步流程常量齐备（选发码方式 / 触发发码 / 码错文案 / 弹窗定位 / 墙判定词）
     assert SMS_RECEIVE_OPTS and SMS_SEND_OPTS and SMS_ERROR_TEXTS and SMS_MODAL_SELS and WALL_KEYWORDS
+    assert any('second_verify' in s or 'second-verify' in s for s in SMS_MODAL_SELS)
     assert any("接收短信" in s for s in SMS_RECEIVE_OPTS)
     assert any("获取验证码" in s for s in SMS_SEND_OPTS)
     assert "验证码错误" in SMS_ERROR_TEXTS and "验证码已过期" in SMS_ERROR_TEXTS
     assert any("modal" in s for s in SMS_MODAL_SELS)
     assert "接收短信" in WALL_KEYWORDS and "身份验证" in WALL_KEYWORDS
-    print("✅ selftest 通过（短信选择器 + 弹窗定位 + 墙判定 + 路径/代理/路由 + plan + 验证码文件协议）")
+    # 读回对账模块（platform_readback）离线冒烟：标题+时间窗匹配语义 + 发前快照排除
+    from platform_readback import WorkItem, find_published_work, capture_douyin_snapshot
+    _now_ms = int(time.time() * 1000)
+    _w = WorkItem("1", "读回对账自检标题十二字", "published", _now_ms - 60_000)
+    assert find_published_work([_w], "读回对账自检", since_ms=_now_ms - 300_000) is _w
+    assert find_published_work([_w], "不相干标题", since_ms=None) is None
+    # 发前快照排除：发布前就存在（在快照里）的同标题作品不认；不在快照里的才认
+    assert find_published_work([_w], "读回对账自检", since_ms=None, exclude_ids={"1"}) is None
+    assert find_published_work([_w], "读回对账自检", since_ms=None, exclude_ids={"9"}) is _w
+    assert callable(capture_douyin_snapshot)
+    # 人类节奏（human_pace）：阶段区间齐备、采样有效、复核按内容加权
+    import human_pace
+    assert set(human_pace.HUMAN_PACE_RANGES) == {"task-switch", "field-switch", "verification", "review", "commit"}
+    for _st in human_pace.HUMAN_PACE_RANGES:
+        for _ in range(20):
+            assert human_pace.sample_ms(_st, 100) >= 0
+    assert human_pace.sample_ms("review", 0) >= 2000
+    assert human_pace.sample_ms("review", 5000) >= 10000     # 内容加权后明显抬升
+    # 单次提交契约（静态检查）：_click_publish 内含就绪等待 + 提交前停顿
+    import inspect as _ins
+    _src = _ins.getsource(_click_publish)
+    assert "_wait_publish_button_ready" in _src and "pause_before_commit" in _src
+    assert callable(_wait_publish_button_ready)
+    print("✅ selftest 通过（短信选择器 + 弹窗定位 + 墙判定 + 路径/代理/路由 + plan + 验证码文件协议 + 读回对账 + 发前快照 + 人类节奏 + 单次提交契约）")
     return 0
 
 

--- a/skills/shared/scripts/human_pace.py
+++ b/skills/shared/scripts/human_pace.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""human_pace.py — 浏览器发布动作的统一人类节奏控制。
+
+节奏控制：按动作语义分档的随机停顿（humanPace 系列）：
+按**动作语义**（而不是散落的固定毫秒）生成停顿——任务切换、字段切换、验证、
+复核、提交各有其自然的停顿区间，并用两个随机样本的均值（centered random）
+削弱「总取到区间端点」的不自然感。
+
+用法（脚本内）：
+    import human_pace
+    human_pace.pace("task-switch")                  # 动作间停顿
+    human_pace.pace("review", content_length)       # 复核停顿（按内容长度加权）
+    human_pace.pause_before_commit(content_length)  # 填完后：复核 + 提交双停顿
+
+测试/联调时置 EASEL_PACE_SKIP=1 全局跳过等待（selftest 用它保持离线快跑）。
+"""
+from __future__ import annotations
+
+import os
+import random
+import time
+
+# 各动作语义的停顿区间（毫秒）——各档区间如下
+HUMAN_PACE_RANGES: dict[str, tuple[int, int]] = {
+    "task-switch": (1800, 4500),   # 从一个任务切到另一个（打开页/进入编辑器）
+    "field-switch": (650, 1800),   # 字段之间切换（标题→简介）
+    "verification": (1200, 3000),  # 验证相关动作之间
+    "review": (2000, 5000),        # 提交前的复核（再加内容长度加权）
+    "commit": (1200, 3200),        # 复核完成到点下提交的反应时间
+}
+
+
+def sample_ms(stage: str, content_length: int = 0, rng=random.random) -> int:
+    """按阶段采样停顿毫秒数。两个随机样本取均值 → 减少取到区间端点的概率。
+    review 阶段额外加 min(8s, 内容长度×12ms) —— 内容越多「看」得越久。"""
+    lo, hi = HUMAN_PACE_RANGES[stage]
+    centered = (rng() + rng()) / 2
+    review_extra = min(8000, max(0, content_length) * 12) if stage == "review" else 0
+    return round(lo + (hi - lo) * centered + review_extra)
+
+
+def pace(stage: str, content_length: int = 0) -> None:
+    """等待一个该阶段的自然停顿。EASEL_PACE_SKIP=1 时跳过（测试）。"""
+    if os.environ.get("EASEL_PACE_SKIP") == "1":
+        return
+    time.sleep(sample_ms(stage, content_length) / 1000.0)
+
+
+def pause_before_commit(content_length: int = 0) -> None:
+    """填写完成后、点提交前：先复核（按内容长度）再以独立反应时间提交。
+    （复核与提交是两个分离的停顿）"""
+    pace("review", content_length)
+    pace("commit")

--- a/skills/shared/scripts/platform_readback.py
+++ b/skills/shared/scripts/platform_readback.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""platform_readback.py — 平台读回对账（发布可靠性核心）。
+
+发布后回到创作者中心**读本人作品列表**，与本次发布对账（标题 + 时间窗），
+对上才算「已发布」。协议取自生产级发布引擎的读回对账实践：
+抖音 = 页面内 fetch work_list 接口（同域、登录态随 cookie 走），小红书 = 捕获
+页面自身签名响应（待补）。原则：没有平台侧证据时保留「未核实」，
+不凭脚本结束声明已提交。
+
+outcome 四档（调用方据此落回执，绝不把未核实当成功）：
+  verified       读回对上（标题前缀 + since 时间窗）——附带作品 id 与状态为准
+  unverified     读回通了但多轮未见新作品（索引延迟/审核队列等，保留待查）
+  login_required 读回时登录态已失效——明确报「需重新登录」
+  readback_error 读回通道本身失败（网络/页面结构改版），附原始证据
+
+非目标：不管理登录、不碰凭据、不写状态文件（由调用方决定如何落回执）。
+"""
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlencode
+
+DOUYIN_MANAGE_URL = "https://creator.douyin.com/creator-micro/content/manage"
+DOUYIN_WORK_LIST_URL = "https://creator.douyin.com/janus/douyin/creator/pc/work_list"
+DOUYIN_PROFILE_API = "https://creator.douyin.com/web/api/media/user/info/?aid=1128"
+
+# 标题前缀匹配长度：与 douyin_publish._verify_published 现有口径一致（前 12 字）
+TITLE_KEY_LEN = 12
+# 时间窗容差：允许平台时间戳精度/索引延迟（发布到出现在列表里的间隔）
+SINCE_TOLERANCE_MS = 10 * 60 * 1000
+
+
+@dataclass
+class WorkItem:
+    platform_content_id: str
+    title: str
+    status: str
+    published_at_ms: int | None = None
+    stats: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "platform_content_id": self.platform_content_id,
+            "title": self.title,
+            "status": self.status,
+            "published_at_ms": self.published_at_ms,
+            "stats": self.stats,
+        }
+
+
+@dataclass
+class ReadbackResult:
+    outcome: str  # verified | unverified | login_required | readback_error
+    matched: WorkItem | None = None
+    candidates: list[WorkItem] = field(default_factory=list)
+    evidence: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome,
+            "matched": self.matched.as_dict() if self.matched else None,
+            "candidates": [w.as_dict() for w in self.candidates],
+            "evidence": self.evidence,
+            "error": self.error,
+        }
+
+
+class LoginRequiredError(RuntimeError):
+    """读回时确认登录态已失效（区别于通道故障——那是 readback_error）。"""
+
+
+# 页面内 fetch：同域请求自动带 cookie；返回结构化结果而不是裸文本，便于错误诊断。
+_JS_FETCH_JSON = """
+async ([url, timeoutMs]) => {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const resp = await fetch(url, {
+      credentials: 'include',
+      signal: ctrl.signal,
+      headers: { 'accept': 'application/json, text/plain, */*' },
+    });
+    const text = await resp.text();
+    let body = null, parseError = null;
+    try { body = JSON.parse(text); } catch (e) { parseError = String(e); }
+    return { httpStatus: resp.status, finalUrl: resp.url, body, parseError,
+             textHead: text.slice(0, 300) };
+  } catch (e) {
+    return { fetchError: String((e && e.message) || e) };
+  } finally { clearTimeout(timer); }
+}
+"""
+
+
+def _navigation_safe_evaluate(page, script: str, arg, *, retries: int = 3):
+    """page.evaluate 的导航竞态容错（页面跳转瞬间 context 销毁会抛错，重试即可）。"""
+    last_error: Exception | None = None
+    for attempt in range(max(1, retries)):
+        try:
+            return page.evaluate(script, arg)
+        except Exception as e:  # noqa: BLE001 —— 只挑导航竞态重试，其余上抛
+            msg = str(e)
+            racing = ("Execution context was destroyed" in msg
+                      or "Cannot find context" in msg
+                      or "navigation" in msg.lower())
+            if not racing:
+                raise
+            last_error = e
+            time.sleep(0.8 * (attempt + 1))
+    raise last_error  # type: ignore[misc]
+
+
+def _epoch_ms(value: Any) -> int | None:
+    """秒/毫秒 epoch 归一化。"""
+    try:
+        n = float(value or 0)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return int(n * 1000) if n < 10_000_000_000 else int(n)
+
+
+def _normalize_douyin_status(status: Any, public_time: Any) -> str:
+    """作品状态归一化（平台状态码 → 统一枚举）。"""
+    if isinstance(status, (int, float)):
+        return str(status)
+    s = status if isinstance(status, dict) else {}
+    if s.get("is_delete"):
+        return "deleted"
+    if s.get("is_prohibited"):
+        return "prohibited"
+    if s.get("in_reviewing"):
+        return "reviewing"
+    if s.get("is_private"):
+        return "private"
+    try:
+        public_s = float(public_time or 0)
+    except (TypeError, ValueError):
+        public_s = 0
+    if public_s > time.time():
+        return "scheduled"
+    return "published"
+
+
+def _first_id(item: dict) -> str:
+    for key in ("aweme_id", "item_id", "id"):
+        v = item.get(key)
+        if v is not None and str(v).strip():
+            return str(v).strip()
+    raise ValueError("作品缺少 id（aweme_id/item_id）")
+
+
+def read_douyin_works(page, *, limit: int = 20, evaluate_retries: int = 3) -> list[WorkItem]:
+    """在创作者中心页读取本人作品列表（页面内 fetch，登录态随 cookie 走）。
+
+    取数口径：
+    count / max_cursor / status=0 / scene=7 / device_platform=webapp / aid=2906，
+    解析 data.work_list（回退 aweme_list/items）。本函数只取第一页（对账不需要全量）。
+    登录失效 → raise LoginRequiredError；通道故障 → 抛原始异常（调用方分类）。
+    """
+    limit = max(1, min(50, int(limit or 20)))
+    try:
+        current_url = page.url or ""
+    except Exception:  # noqa: BLE001
+        current_url = ""
+    if DOUYIN_MANAGE_URL not in current_url:
+        page.goto(DOUYIN_MANAGE_URL, wait_until="domcontentloaded")
+        page.wait_for_timeout(1500)  # 页面异步渲染，等上下文稳定
+    try:
+        landed = page.url or ""
+    except Exception:  # noqa: BLE001
+        landed = ""
+    if "creator.douyin.com" in landed and "login" in landed.lower():
+        raise LoginRequiredError(f"会话已失效（跳转登录页：{landed[:120]}）")
+
+    query = urlencode({
+        "count": limit,
+        "max_cursor": 0,
+        "status": "0",
+        "scene": "7",
+        "device_platform": "webapp",
+        "aid": "2906",
+    })
+    result = _navigation_safe_evaluate(
+        page, _JS_FETCH_JSON, [f"{DOUYIN_WORK_LIST_URL}?{query}", 15000],
+        retries=evaluate_retries,
+    )
+    if not isinstance(result, dict):
+        raise RuntimeError(f"读回返回结构异常：{type(result).__name__}")
+    if result.get("fetchError"):
+        raise RuntimeError(f"读回请求失败：{result['fetchError']}")
+    http_status = int(result.get("httpStatus") or 0)
+    if http_status in (401, 403):
+        raise LoginRequiredError(f"读回 HTTP {http_status}")
+    body = result.get("body")
+    if not isinstance(body, dict):
+        final_url = str(result.get("finalUrl") or "")
+        try:
+            page_url = page.url or ""
+        except Exception:  # noqa: BLE001
+            page_url = ""
+        if "login" in final_url.lower() or "login" in page_url.lower():
+            raise LoginRequiredError("会话已失效（响应重定向到登录页）")
+        raise RuntimeError(
+            f"读回响应非 JSON（HTTP {http_status}）：{str(result.get('textHead') or '')[:120]}")
+    status_code = body.get("status_code")
+    if status_code not in (0, None):
+        msg = str(body.get("status_msg") or body.get("message") or "")
+        if "登录" in msg or "login" in msg.lower() or status_code in (8, 1002, 2154):
+            raise LoginRequiredError(f"读回被拒：status_code={status_code} {msg}")
+        raise RuntimeError(f"读回接口报错：status_code={status_code} {msg}")
+
+    data = body.get("data") if isinstance(body.get("data"), dict) else {}
+    raw_items = (data.get("work_list") or body.get("aweme_list")
+                 or data.get("aweme_list") or body.get("items") or [])
+    if not isinstance(raw_items, list):
+        raise RuntimeError("读回响应缺少 work_list（页面结构可能改版）")
+
+    works: list[WorkItem] = []
+    for raw in raw_items[:limit]:
+        if not isinstance(raw, dict):
+            continue
+        statistics = raw.get("statistics") if isinstance(raw.get("statistics"), dict) else {}
+        works.append(WorkItem(
+            platform_content_id=_first_id(raw),
+            title=str(raw.get("desc") or raw.get("title") or "").strip(),
+            status=_normalize_douyin_status(raw.get("status"), raw.get("public_time")),
+            published_at_ms=_epoch_ms(raw.get("create_time") or raw.get("public_time")),
+            stats={
+                "play_count": statistics.get("play_count"),
+                "digg_count": statistics.get("digg_count"),
+                "comment_count": statistics.get("comment_count"),
+            },
+        ))
+    return works
+
+
+def read_douyin_account(page) -> dict[str, Any]:
+    """读创作者中心当前登录账号身份（uid/昵称/粉丝）——「我是谁」接口。
+
+    读当前账号（user/info, aid=1128）：
+    登录态上报、发布回执的账号身份快照、身份核验共用这一条读法。
+    登录失效 raise LoginRequiredError；响应缺 uid raise RuntimeError。
+    """
+    try:
+        current_url = page.url or ""
+    except Exception:  # noqa: BLE001
+        current_url = ""
+    if "creator.douyin.com" not in current_url:
+        page.goto(DOUYIN_MANAGE_URL, wait_until="domcontentloaded")
+        page.wait_for_timeout(1500)
+    result = _navigation_safe_evaluate(
+        page, _JS_FETCH_JSON, [DOUYIN_PROFILE_API, 15000], retries=2)
+    if not isinstance(result, dict):
+        raise RuntimeError(f"账号读取返回结构异常：{type(result).__name__}")
+    if result.get("fetchError"):
+        raise RuntimeError(f"账号读取请求失败：{result['fetchError']}")
+    body = result.get("body")
+    if not isinstance(body, dict):
+        raise RuntimeError(f"账号读取响应非 JSON（HTTP {result.get('httpStatus')}）")
+    status_code = body.get("status_code")
+    if status_code not in (0, None):
+        msg = str(body.get("status_msg") or "")
+        if "登录" in msg or status_code in (8, 1002, 2154):
+            raise LoginRequiredError(f"账号读取被拒：status_code={status_code} {msg}")
+        raise RuntimeError(f"账号读取接口报错：status_code={status_code} {msg}")
+    user = body.get("user_info") if isinstance(body.get("user_info"), dict) else (
+        body.get("user") if isinstance(body.get("user"), dict) else {})
+    uid = str(user.get("uid") or user.get("sec_uid") or user.get("open_id") or "").strip()
+    if not uid:
+        raise RuntimeError("账号信息缺少 uid（页面结构可能改版）")
+
+    def _num(v):  # noqa: ANN001
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    return {
+        "platform_account_id": uid,
+        "display_name": str(user.get("nickname") or user.get("name") or uid).strip(),
+        "username": str(user.get("unique_id") or user.get("short_id") or "").strip() or None,
+        "fans_count": _num(user.get("follower_count")),
+        "work_count": _num(user.get("aweme_count")),
+    }
+
+
+def capture_douyin_snapshot(page) -> set[str]:
+    """发前快照：读取当前作品列表的全部作品 id。
+    发布前抓一遍，读回时用它排除「本来就存在的旧作品」，让对账只认**新出现**的条目。
+    失败（未登录/通道异常）返回空集合——对账自动退化为标题+时间窗，不影响主流程。"""
+    try:
+        works = read_douyin_works(page, limit=30)
+        return {w.platform_content_id for w in works}
+    except Exception:
+        return set()
+
+
+def find_published_work(works: list[WorkItem], title: str, *,
+                        since_ms: int | None = None,
+                        key_len: int = TITLE_KEY_LEN,
+                        exclude_ids: set[str] | None = None) -> WorkItem | None:
+    """对账：列表中找属于本次发布的作品（标题前缀命中 + 不早于 since 时间窗）。
+
+    - 标题为空 → 无法对账（返回 None，调用方按 unverified 处理）。
+    - since_ms 给了时：作品发布时间明显早于 since 的跳过（防同标题旧作品误判），
+      容差 SINCE_TOLERANCE_MS 吸收平台时间戳精度与索引延迟。
+    - exclude_ids（发前快照）里的 id 视为旧作品跳过——发布前就存在的条目不可能是本次，
+      同标题+时间戳精度边缘时它是比时间窗更硬的证据。
+    """
+    key = (title or "").strip().replace("\n", " ")[:key_len]
+    if not key:
+        return None
+    for w in works:
+        if key not in (w.title or ""):
+            continue
+        if exclude_ids and w.platform_content_id in exclude_ids:
+            continue
+        if since_ms and w.published_at_ms and (w.published_at_ms + SINCE_TOLERANCE_MS) < since_ms:
+            continue
+        return w
+    return None
+
+
+def verify_douyin_publish(page, *, title: str, since_ms: int | None = None,
+                          limit: int = 20, attempts: int = 4,
+                          delay_s: float = 12.0,
+                          snapshot_ids: set[str] | None = None) -> ReadbackResult:
+    """发布后对账入口：多轮读回（列表异步更新，给平台索引时间）。
+
+    返回 ReadbackResult；除 KeyboardInterrupt 外不抛异常——
+      verified        对上（matched 为对应作品）
+      unverified      通道通、未见新作品（candidates 为读到的近期作品，供诊断）
+      login_required  登录失效
+      readback_error  通道故障（error 带原始信息）
+    """
+    last_error: Exception | None = None
+    last_candidates: list[WorkItem] = []
+    evidence: dict[str, Any] = {"attempts": 0}
+    for i in range(max(1, attempts)):
+        evidence = {"attempts": i + 1, "checked_at": int(time.time())}
+        try:
+            works = read_douyin_works(page, limit=limit)
+        except LoginRequiredError as e:
+            return ReadbackResult(outcome="login_required", evidence=evidence, error=str(e))
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            print(f"⚠️ 读回第 {i + 1}/{attempts} 轮失败：{e}", file=sys.stderr)
+            if i + 1 < attempts:
+                time.sleep(delay_s)
+            continue
+        last_candidates = works
+        evidence["count"] = len(works)
+        matched = find_published_work(works, title, since_ms=since_ms, exclude_ids=snapshot_ids)
+        if matched:
+            # 顺带读账号身份快照（回执标准件；失败不影响对账结论）
+            try:
+                evidence["account"] = read_douyin_account(page)
+            except Exception as e:  # noqa: BLE001
+                evidence["account_error"] = str(e)
+            print(f"✅ 读回对账通过：{matched.platform_content_id}（{matched.status}）", file=sys.stderr)
+            return ReadbackResult(outcome="verified", matched=matched,
+                                  candidates=works[:5], evidence=evidence)
+        print(f"… 读回第 {i + 1}/{attempts} 轮：列表 {len(works)} 条未见本次作品", file=sys.stderr)
+        if i + 1 < attempts:
+            time.sleep(delay_s)
+    if last_error is not None and not last_candidates:
+        return ReadbackResult(outcome="readback_error", evidence=evidence, error=str(last_error))
+    return ReadbackResult(outcome="unverified", candidates=last_candidates[:5], evidence=evidence)

--- a/web/app.py
+++ b/web/app.py
@@ -309,7 +309,7 @@ def _proxy_env() -> dict[str, str]:
     env.setdefault('EASEL_ROOT', str(PROJECT_ROOT))
     env.setdefault('http_proxy', os.environ.get('EASEL_PROXY', ''))
     env.setdefault('https_proxy', os.environ.get('EASEL_PROXY', ''))
-    env.setdefault('no_proxy', 'localhost,127.0.0.1,*.xiaohongshu.com,*.devops.xiaohongshu.com,10.*')
+    env.setdefault('no_proxy', 'localhost,127.0.0.1,10.*,*.xiaohongshu.com,*.devops.xiaohongshu.com,*.douyin.com,*.kuaishou.com,*.zhihu.com,*.bilibili.com,*.weixin.qq.com,*.qq.com')
     return env
 
 
@@ -2144,7 +2144,7 @@ async def api_publish(platform: str, req: PublishRequest):
             cmd += ['--desc', req.body[:2000]]
     elif platform == 'douyin':
         base = [py, str(SHARED_SCRIPTS / 'douyin_publish.py')]
-        cmd = base + ['publish-video', '--video', vids[0]] if vids else base + ['publish', '--images', ','.join(imgs)]
+        cmd = base + ['publish-video', '--no-proxy', '--video', vids[0]] if vids else base + ['publish', '--no-proxy', '--images', ','.join(imgs)]
         cmd += ['--title', title, '--content', req.body, '--tags', tags, '--exec']
         # 抖音发布可能触发风控短信墙——异步跑 + 状态/验证码文件，前端轮询到 sms_required 时弹输入框
         PUBLISH_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

The Douyin publish pipeline decides "published" from the UI layer only (page URL / toast / form reset). On real traffic this produces both false positives (UI says done, nothing was actually published) and false negatives (publish succeeded, but a late SMS verification wall intercepted the click and the run timed out).

Three concrete failure classes observed live:

1. **No data-level confirmation** of what was actually posted.
2. **SMS risk wall race** — the wall renders later than the previous fixed 2.5s check; the click then lands under the mask and the run times out, even though the platform had already sent the SMS.
3. **Proxy interference** — publishes ran through whatever proxy the environment had configured; a foreign egress is a high-risk signal for domestic platforms (login and publish).

## What this PR does

### New: `skills/shared/scripts/platform_readback.py`
Data-level publish confirmation:

- pre-publish **snapshot** of the creator work list (set of work ids)
- post-publish **readback** (title prefix + creation-time window + snapshot exclusion)
- four outcomes: `verified` / `unverified` / `login_required` / `readback_error`
- success is only reported when the readback actually matches

### New: `skills/shared/scripts/human_pace.py`
Semantic pacing delays (task-switch 1.8–4.5s / field-switch 0.65–1.8s / review+commit double pause), centered-random sampled.

### `skills/shared/scripts/douyin_publish.py`
- upload-complete detection requires **two consecutive stable checks** and `aria-valuenow >= 100` when a progress bar exists
- per-character randomized typing (65–140 ms)
- **single-commit contract**: exactly one click on "publish", after a dedicated button-ready convergence phase
- **SMS wall races fixed**: poll up to 12 s after the click for the wall to render; check the wall first during teardown; support a one-shot resend signal file (`<code_file>.resend`)
- launch with `--no-proxy-server` when no proxy is configured

### `skills/openclaw/skill-douyin-upload/SKILL.md`
Chat-driven publish interaction guide: poll the status file every 2–3 s, raise an `ask_user` card for the SMS code (with resend / cancel options), write the code back immediately.

### `web/app.py`
- pass `--no-proxy` for Douyin publishes
- extend the `no_proxy` whitelist with domestic platform domains (douyin / kuaishou / zhihu / bilibili / weixin / qq)

## How it was verified

- offline `selftest` green (includes readback, snapshot, pacing, single-commit assertions)
- live end-to-end publish on a real account: readback matched the new work (work id + account name written into the status file); an SMS-wall run recovered correctly through the resend + code-file protocol

## Notes

The readback module is platform-agnostic; extending it to the other publishers (kuaishou / xiaohongshu / zhihu / bilibili) is a natural follow-up.
